### PR TITLE
STAC-2834: Rename dd api key header to sts header

### DIFF
--- a/agent/collector.go
+++ b/agent/collector.go
@@ -271,9 +271,9 @@ func (l *Collector) postToAPIwithEncoding(endpoint config.APIEndpoint, checkPath
 	}
 
 	req.Header.Add("content-encoding", contentEncoding)
-	req.Header.Add("X-Dd-APIKey", endpoint.APIKey)
-	req.Header.Add("X-Dd-Hostname", l.cfg.HostName)
-	req.Header.Add("X-Dd-Processagentversion", Version)
+	req.Header.Add("sts-api-key", endpoint.APIKey)
+	req.Header.Add("sts-hostname", l.cfg.HostName)
+	req.Header.Add("sts-processagentversion", Version)
 
 	ctx, cancel := context.WithTimeout(context.Background(), ReqCtxTimeout)
 	defer cancel()


### PR DESCRIPTION
Rename api key header to fix api key validation when pushing to the receiver