### PR TITLE
Fixes for connection metrics

### DIFF
--- a/checks/net.go
+++ b/checks/net.go
@@ -173,6 +173,7 @@ func (c *ConnectionsCheck) formatConnections(conns []tracer.ConnectionStats, las
 		})
 	}
 	c.prevCheckConns = conns
+	c.prevCheckTime = time.Now()
 	return cxs
 }
 
@@ -210,19 +211,17 @@ func calculateDirection(d tracer.Direction) model.ConnectionDirection {
 }
 
 func batchConnections(cfg *config.AgentConfig, groupID int32, cxs []*model.Connection) []model.MessageBody {
-	groupSize := groupSize(len(cxs), cfg.MaxPerMessage)
-	batches := make([]model.MessageBody, 0, groupSize)
+	batches := make([]model.MessageBody, 0, 1)
 
-	for len(cxs) > 0 {
-		batchSize := min(cfg.MaxPerMessage, len(cxs))
-		batches = append(batches, &model.CollectorConnections{
-			HostName:    cfg.HostName,
-			Connections: cxs[:batchSize],
-			GroupId:     groupID,
-			GroupSize:   groupSize,
-		})
-		cxs = cxs[batchSize:]
-	}
+	// STS: Disable batching for now
+	batchSize := min(cfg.MaxPerMessage, len(cxs))
+	batches = append(batches, &model.CollectorConnections{
+		HostName:    cfg.HostName,
+		Connections: cxs[:batchSize],
+		GroupId:     groupID,
+		GroupSize:   1,
+	})
+
 	return batches
 }
 

--- a/checks/net_test.go
+++ b/checks/net_test.go
@@ -12,7 +12,7 @@ func makeConnection(pid int32) *model.Connection {
 	return &model.Connection{Pid: pid}
 }
 
-func TestNetworkConnectionBatching(t *testing.T) {
+func TestNetworkConnectionMax(t *testing.T) {
 	p := []*model.Connection{
 		makeConnection(1),
 		makeConnection(2),
@@ -31,14 +31,14 @@ func TestNetworkConnectionBatching(t *testing.T) {
 		{
 			cur:            []*model.Connection{p[0], p[1], p[2]},
 			maxSize:        1,
-			expectedTotal:  3,
-			expectedChunks: 3,
+			expectedTotal:  1,
+			expectedChunks: 1,
 		},
 		{
 			cur:            []*model.Connection{p[0], p[1], p[2]},
 			maxSize:        2,
-			expectedTotal:  3,
-			expectedChunks: 2,
+			expectedTotal:  2,
+			expectedChunks: 1,
 		},
 		{
 			cur:            []*model.Connection{p[0], p[1], p[2], p[3]},
@@ -49,14 +49,14 @@ func TestNetworkConnectionBatching(t *testing.T) {
 		{
 			cur:            []*model.Connection{p[0], p[1], p[2], p[3]},
 			maxSize:        3,
-			expectedTotal:  4,
-			expectedChunks: 2,
+			expectedTotal:  3,
+			expectedChunks: 1,
 		},
 		{
 			cur:            []*model.Connection{p[0], p[1], p[2], p[3], p[2], p[3]},
 			maxSize:        2,
-			expectedTotal:  6,
-			expectedChunks: 3,
+			expectedTotal:  2,
+			expectedChunks: 1,
 		},
 	} {
 		cfg.MaxPerMessage = tc.maxSize

--- a/checks/process.go
+++ b/checks/process.go
@@ -152,10 +152,9 @@ func fmtProcesses(
 		})
 		// STS: for now we disable chunking until we support chunked receiving. Otherwise ppid
 		// get separated
-		// if len(chunk) == cfg.MaxPerMessage {
-		//  	chunked = append(chunked, chunk)
-		//  	chunk = make([]*model.Process, 0, cfg.MaxPerMessage)
-		// }
+		if len(chunk) == cfg.MaxPerMessage {
+			break
+		}
 	}
 	if len(chunk) > 0 {
 		chunked = append(chunked, chunk)

--- a/conf-dev.yaml
+++ b/conf-dev.yaml
@@ -1,4 +1,5 @@
 log_level: info
+
 api_key: API_KEY
 process_agent_enabled: true
 process_config:
@@ -8,7 +9,7 @@ process_config:
 #  process_dd_url: http://localhost:7077/stsAgent
 
 # Use this when running process agent in the vagrant vms
-  process_dd_url: http://192.168.56.1:7077/stsAgent
+  process_dd_url: http://localhost:7077/stsAgent
 
   queue_size: 10
   network_tracing_enabled: 'true'

--- a/config/config.go
+++ b/config/config.go
@@ -157,7 +157,7 @@ func NewDefaultAgentConfig() *AgentConfig {
 		LogToConsole:  false,
 		QueueSize:     20,
 		MaxProcFDs:    200,
-		MaxPerMessage: 100,
+		MaxPerMessage: 2000,
 		AllowRealTime: true,
 		HostName:      "",
 		Transport:     NewDefaultTransport(),

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 665936af25bb1c259458b72b68e338a40879a7736542cd18c240ba829a719d6e
-updated: 2018-11-12T14:16:40.915255818+01:00
+updated: 2018-11-21T10:11:12.440916795+01:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
@@ -289,7 +289,7 @@ imports:
 - name: github.com/StackExchange/wmi
   version: b12b22c5341f0c26d88c4d66176330500e84db68
 - name: github.com/StackVista/tcptracer-bpf
-  version: 3bd9f9e000c00ea19e0e28bbbb805d0444f122ac
+  version: 1fba650acaa806c730818c630c94eb595bcd4f94
   vcs: git
   subpackages:
   - pkg/tracer


### PR DESCRIPTION
Small fixes to support the metrics on connections:
- Use newest tcptracer-bpf because it captures more data
- Fix issue where the net.go check would not correctly update the prevCheckTime
- Drop batching for now in favor of limiting. We'll reenable this once we look at batching for real (https://stackstate.atlassian.net/browse/STAC-3233)