### PR TITLE
STAC-4139 centos6 builds

### DIFF
--- a/.circleci/builder/Dockerfile
+++ b/.circleci/builder/Dockerfile
@@ -7,7 +7,7 @@ RUN yum install -y rsync \
 # Provide kernel 4.4 header that include eBPF header needed to build linux network tracer
 RUN curl -OL https://elrepo.org/linux/kernel/el6/x86_64/RPMS/kernel-lt-headers-4.4.176-1.el6.elrepo.x86_64.rpm \
     && rpm2cpio kernel-lt-headers-4.4.176-1.el6.elrepo.x86_64.rpm | cpio -idm \
-    && rsync -vr ./usr/ /usr/ \
+    && rsync -r ./usr/ /usr/ \
     && rm -rf kernel-lt-headers-4.4.176-1.el6.elrepo.x86_64.rpm ./usr
 
 # Upgrade gcc to 4.7 needed to build gobpf/elf

--- a/.circleci/builder/Dockerfile
+++ b/.circleci/builder/Dockerfile
@@ -12,4 +12,4 @@ RUN curl -OL https://elrepo.org/linux/kernel/el6/x86_64/RPMS/kernel-lt-headers-4
 
 # Upgrade gcc to 4.7 needed to build gobpf/elf
 RUN curl https://people.centos.org/tru/devtools-1.1/devtools-1.1.repo -o /etc/yum.repos.d/devtools-1.1.repo \
-    && yum install -y yum install devtoolset-1.1-gcc
+    && yum install -y devtoolset-1.1-gcc

--- a/.circleci/builder/Dockerfile
+++ b/.circleci/builder/Dockerfile
@@ -1,89 +1,15 @@
-FROM golang:1.10.1
+FROM stackstate/stackstate-agent-runner-gitlab:centos6
 
-RUN sed -i 's/^#\s*\(deb.*universe\)$/\1/g' /etc/apt/sources.list \
-    && sed -i 's/^#\s*\(deb.*multiverse\)$/\1/g' /etc/apt/sources.list \
-    && sed -i 's/main/main contrib non-free/' /etc/apt/sources.list
+RUN yum install -y rsync \
+    && gem install rake fpm deb-s3 \
+    && curl https://glide.sh/get | sh
 
-RUN apt-get update && apt-get install -y python2.7-dev autoconf autogen intltool libssl1.0-dev
-RUN apt-get install -y libsnmp-base libsnmp-dev libpq-dev snmp-mibs-downloader libsystemd-dev
+# Provide kernel 4.4 header that include eBPF header needed to build linux network tracer
+RUN curl -OL https://elrepo.org/linux/kernel/el6/x86_64/RPMS/kernel-lt-headers-4.4.176-1.el6.elrepo.x86_64.rpm \
+    && rpm2cpio kernel-lt-headers-4.4.176-1.el6.elrepo.x86_64.rpm | cpio -idm \
+    && rsync -vr ./usr/ /usr/ \
+    && rm -rf kernel-lt-headers-4.4.176-1.el6.elrepo.x86_64.rpm ./usr
 
-RUN go get -u golang.org/x/lint/golint
-
-# Ruby,,,
-RUN mkdir -p /usr/local/etc \
-	&& { \
-		echo 'install: --no-document'; \
-		echo 'update: --no-document'; \
-	} >> /usr/local/etc/gemrc
-
-ENV RUBY_MAJOR 2.4
-ENV RUBY_VERSION 2.4.2
-ENV RUBY_DOWNLOAD_SHA256 748a8980d30141bd1a4124e11745bb105b436fb1890826e0d2b9ea31af27f735
-ENV RUBYGEMS_VERSION 2.6.12
-
-# some of ruby's build scripts are written in ruby
-#   we purge system ruby later to make sure our final image uses what we just built
-RUN set -ex \
-	\
-	&& buildDeps=' \
-		bison \
-		dpkg-dev \
-		libgdbm-dev \
-		ruby \
-	' \
-	&& apt-get update \
-	&& apt-get install -y --no-install-recommends $buildDeps \
-	&& rm -rf /var/lib/apt/lists/* \
-	\
-	&& wget -O ruby.tar.xz "https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR%-rc}/ruby-$RUBY_VERSION.tar.xz" \
-	&& echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum -c - \
-	\
-	&& mkdir -p /usr/src/ruby \
-	&& tar -xJf ruby.tar.xz -C /usr/src/ruby --strip-components=1 \
-	&& rm ruby.tar.xz \
-	\
-	&& cd /usr/src/ruby \
-	\
-# hack in "ENABLE_PATH_CHECK" disabling to suppress:
-#   warning: Insecure world writable dir
-	&& { \
-		echo '#define ENABLE_PATH_CHECK 0'; \
-		echo; \
-		cat file.c; \
-	} > file.c.new \
-	&& mv file.c.new file.c \
-	\
-	&& autoconf \
-	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
-	&& ./configure \
-		--build="$gnuArch" \
-		--disable-install-doc \
-		--enable-shared \
-        --with-openssl=/usr/lib/ssl \
-	&& make -j "$(nproc)" \
-	&& make install \
-	\
-	&& apt-get purge -y --auto-remove $buildDeps \
-	&& cd / \
-	&& gem update --system "$RUBYGEMS_VERSION" \
-	&& gem install deb-s3 \
-	&& rm -r /usr/src/ruby
-
-ENV BUNDLER_VERSION 1.15.3
-
-RUN gem install bundler --version "$BUNDLER_VERSION"
-
-RUN apt-get update && apt-get install -y python-pip \
-      && pip install virtualenv==16.0.0
-
-# install things globally, for great justice
-# and don't create ".bundle" in all our apps
-ENV GEM_HOME /usr/local/bundle
-ENV BUNDLE_PATH="$GEM_HOME" \
-	BUNDLE_BIN="$GEM_HOME/bin" \
-	BUNDLE_SILENCE_ROOT_WARNING=1 \
-	BUNDLE_APP_CONFIG="$GEM_HOME"
-ENV PATH $BUNDLE_BIN:$PATH
-RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN" \
-	&& chmod 777 "$GEM_HOME" "$BUNDLE_BIN"
-
+# Upgrade gcc to 4.7 needed to build gobpf/elf
+RUN curl https://people.centos.org/tru/devtools-1.1/devtools-1.1.repo -o /etc/yum.repos.d/devtools-1.1.repo \
+    && yum install -y yum install devtoolset-1.1-gcc

--- a/.circleci/builder/Makefile
+++ b/.circleci/builder/Makefile
@@ -1,5 +1,5 @@
 build:
-	docker build -t stackstate/stackstate-agent-runner-circle:process-agent-go1_10_1-0.0.1 .
+	docker build -t stackstate/stackstate-process-agent-runner-gitlab:centos6 .
 
 push:
-	docker push stackstate/stackstate-agent-runner-circle:process-agent-go1_10_1-0.0.1
+	docker push stackstate/stackstate-process-agent-runner-gitlab:centos6

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -35,6 +35,8 @@ build_linux:
       - $CI_PROJECT_DIR/process-agent
       - $CI_PROJECT_DIR/packaging/debian/*.deb
     expire_in: 2 week
+  tags:
+    - sts-aws
 
 # Gitlab dedicated runner in a Windows VM
 build_windows:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,9 +1,6 @@
 stages:
-#- tests
 - build
 - pre_release
-#- publish
-
 
 variables:
   SRC_PATH: /src/github.com/StackVista/stackstate-process-agent
@@ -13,44 +10,30 @@ variables:
   BASH_ENV: /root/.bashrc
 
 build_linux:
-  image: stackstate/stackstate-agent-runner-circle:process-agent-go1_10_1-0.0.1
+  image: stackstate/stackstate-process-agent-runner-gitlab:centos6
   stage: build
   before_script:
     - mkdir -p /go/src/github.com/StackVista
     - ln -s $CI_PROJECT_DIR  /go/src/github.com/StackVista/stackstate-process-agent
-    # - curl -sL -o /usr/local/bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme
-    # - chmod +x /usr/local/bin/gimme
-    # - gimme 1.10.3
-    # - source ~/.gimme/envs/go1.10.3.env
   script:
-    - apt-get install -q -y ca-certificates
     - touch $BASH_ENV
     - echo 'export IMPORT_PATH=$GOPATH/src/github.com/StackVista/stackstate-process-agent' >> $BASH_ENV
     - git status -s
     - echo "export PROCESS_AGENT_VERSION=$(packaging/version.sh)" >> $BASH_ENV
     - echo "export EBPF=${EBPF:-true}" >> $BASH_ENV
     - echo 'export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH' >> $BASH_ENV && source $BASH_ENV
-    - uname -a
-#    - apt-get update && apt-get -y install linux-headers-$(uname -r) rsync rake
-    - apt-get update && apt-get -y install rsync rake
     - rsync -azC --delete ./ $IMPORT_PATH
-    - curl https://glide.sh/get | sh
     - go get golang.org/x/tools/cmd/gorename
     - go get golang.org/x/tools/cmd/eg
     - go get golang.org/x/lint/golint
     - printenv
-    - go version
-    - cd $IMPORT_PATH && rake ci
-    - cd packaging && ./apply_branding.sh
+    - cd $IMPORT_PATH/packaging && ./apply_branding.sh
     - cd $IMPORT_PATH && rake build
-    - apt-get install -y -q rpm
-    - gem install --no-ri --no-rdoc fpm
-    - gem install --no-ri --no-rdoc deb-s3
     - cd $IMPORT_PATH/packaging && ./build_staging_package.sh
   artifacts:
     paths:
-        - $CI_PROJECT_DIR/process-agent
-        - $CI_PROJECT_DIR/packaging/debian/*.deb
+      - $CI_PROJECT_DIR/process-agent
+      - $CI_PROJECT_DIR/packaging/debian/*.deb
     expire_in: 2 week
 
 # Gitlab dedicated runner in a Windows VM
@@ -88,21 +71,17 @@ pre_release_windows:
 
 pre_release_linux:
   stage: pre_release
-  image: stackstate/stackstate-agent-runner-circle:process-agent-go1_10_1-0.0.1
+  image: stackstate/stackstate-process-agent-runner-gitlab:centos6
   dependencies:
     - build_linux
   before_script:
     - mkdir -p /go/src/github.com/StackVista
-    - ln -s $CI_PROJECT_DIR  /go/src/github.com/StackVista/stackstate-process-agent
+    - ln -s $CI_PROJECT_DIR /go/src/github.com/StackVista/stackstate-process-agent
     - echo 'export IMPORT_PATH=$GOPATH/src/github.com/StackVista/stackstate-process-agent' >> $BASH_ENV
     - git status -s
     - echo "export PROCESS_AGENT_VERSION=$(packaging/version.sh)" >> $BASH_ENV
     - echo "export EBPF=${EBPF:-true}" >> $BASH_ENV
     - echo 'export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH' >> $BASH_ENV && source $BASH_ENV
-    - uname -a
-    - apt-get -y -q install s3cmd
-    - gem install --no-ri --no-rdoc fpm
-    - gem install --no-ri --no-rdoc deb-s3
   script:
     - ls -la $IMPORT_PATH
     - ls -la $IMPORT_PATH/packaging

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,7 +7,7 @@ variables:
   STS_AWS_BUCKET: stackstate-process-agent-2-test
   STS_REPO_BRANCH_NAME: $CI_COMMIT_REF_NAME
   CIRCLE_BRANCH: $CI_COMMIT_REF_NAME
-  BASH_ENV: /root/.bashrc
+  BUILD_ENV: /root/.bashrc
 
 build_linux:
   image: stackstate/stackstate-process-agent-runner-gitlab:centos6
@@ -16,18 +16,19 @@ build_linux:
     - mkdir -p /go/src/github.com/StackVista
     - ln -s $CI_PROJECT_DIR  /go/src/github.com/StackVista/stackstate-process-agent
   script:
-    - touch $BASH_ENV
-    - echo 'export IMPORT_PATH=$GOPATH/src/github.com/StackVista/stackstate-process-agent' >> $BASH_ENV
+    - touch $BUILD_ENV
+    - echo 'export IMPORT_PATH=$GOPATH/src/github.com/StackVista/stackstate-process-agent' >> $BUILD_ENV
     - git status -s
-    - echo "export PROCESS_AGENT_VERSION=$(packaging/version.sh)" >> $BASH_ENV
-    - echo "export EBPF=${EBPF:-true}" >> $BASH_ENV
-    - echo 'export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH' >> $BASH_ENV && source $BASH_ENV
+    - echo "export PROCESS_AGENT_VERSION=$(packaging/version.sh)" >> $BUILD_ENV
+    - echo "export EBPF=${EBPF:-true}" >> $BUILD_ENV
+    - echo 'export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH' >> $BUILD_ENV && source $BUILD_ENV
     - rsync -azC --delete ./ $IMPORT_PATH
     - go get golang.org/x/tools/cmd/gorename
     - go get golang.org/x/tools/cmd/eg
     - go get golang.org/x/lint/golint
     - printenv
     - cd $IMPORT_PATH/packaging && ./apply_branding.sh
+    - export CC=/opt/centos/devtoolset-1.1/root/usr/bin/gcc
     - cd $IMPORT_PATH && rake build
     - cd $IMPORT_PATH/packaging && ./build_staging_package.sh
   artifacts:
@@ -35,8 +36,6 @@ build_linux:
       - $CI_PROJECT_DIR/process-agent
       - $CI_PROJECT_DIR/packaging/debian/*.deb
     expire_in: 2 week
-  tags:
-    - sts-aws
 
 # Gitlab dedicated runner in a Windows VM
 build_windows:
@@ -79,11 +78,11 @@ pre_release_linux:
   before_script:
     - mkdir -p /go/src/github.com/StackVista
     - ln -s $CI_PROJECT_DIR /go/src/github.com/StackVista/stackstate-process-agent
-    - echo 'export IMPORT_PATH=$GOPATH/src/github.com/StackVista/stackstate-process-agent' >> $BASH_ENV
+    - echo 'export IMPORT_PATH=$GOPATH/src/github.com/StackVista/stackstate-process-agent' >> $BUILD_ENV
     - git status -s
-    - echo "export PROCESS_AGENT_VERSION=$(packaging/version.sh)" >> $BASH_ENV
-    - echo "export EBPF=${EBPF:-true}" >> $BASH_ENV
-    - echo 'export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH' >> $BASH_ENV && source $BASH_ENV
+    - echo "export PROCESS_AGENT_VERSION=$(packaging/version.sh)" >> $BUILD_ENV
+    - echo "export EBPF=${EBPF:-true}" >> $BUILD_ENV
+    - echo 'export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH' >> $BUILD_ENV && source $BUILD_ENV
   script:
     - ls -la $IMPORT_PATH
     - ls -la $IMPORT_PATH/packaging

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,7 +29,7 @@ build_linux:
     - printenv
     - cd $IMPORT_PATH/packaging && ./apply_branding.sh
     - export CC=/opt/centos/devtoolset-1.1/root/usr/bin/gcc
-    - cd $IMPORT_PATH && rake build
+    - cd $IMPORT_PATH && rake ci
     - cd $IMPORT_PATH/packaging && ./build_staging_package.sh
   artifacts:
     paths:

--- a/packaging/apply_branding.sh
+++ b/packaging/apply_branding.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 
+set -e
+
 # https://regex-golang.appspot.com/assets/html/index.html
 
 export REPLACE_SCOPE="../config ../cmd ../checks"
 export REPLACE_MODE=-w # "-d"
 
 gofmt -l $REPLACE_MODE -r '"DD_HOSTNAME" -> "STS_HOSTNAME"'  $REPLACE_SCOPE
-echo gofmt -l $REPLACE_MODE -r '"DD_API_KEY" -> "STS_API_KEY"' $REPLACE_SCOPE
 gofmt -l $REPLACE_MODE -r '"DD_API_KEY" -> "STS_API_KEY"' $REPLACE_SCOPE
 gofmt -l $REPLACE_MODE -r '"DD_CUSTOM_SENSITIVE_WORDS" -> "STS_CUSTOM_SENSITIVE_WORDS"' $REPLACE_SCOPE
 gofmt -l $REPLACE_MODE -r '"DD_SCRUB_ARGS" -> "STS_SCRUB_ARGS"' $REPLACE_SCOPE
@@ -72,7 +73,7 @@ if [[ $UNAME != MSYS* ]]; then
     echo "Checking replacements..."
 
     which rgrep
-    rgrep --include=*.go "\"DD_"  $PWD/../cmd $PWD/../config $PWD/../checks
+    grep -r --include=*.go "\"DD_"  $PWD/../cmd $PWD/../config $PWD/../checks
 
     RESULT=$?
     if [ $RESULT -eq 0 ]; then

--- a/packaging/apply_branding.sh
+++ b/packaging/apply_branding.sh
@@ -72,7 +72,6 @@ UNAME="$(uname)"
 if [[ $UNAME != MSYS* ]]; then
     echo "Checking replacements..."
 
-    which rgrep
     grep -r --include=*.go "\"DD_"  $PWD/../cmd $PWD/../config $PWD/../checks
 
     RESULT=$?

--- a/packaging/apply_branding.sh
+++ b/packaging/apply_branding.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -e
-
 # https://regex-golang.appspot.com/assets/html/index.html
 
 export REPLACE_SCOPE="../config ../cmd ../checks"

--- a/packaging/publish_staging_package.sh
+++ b/packaging/publish_staging_package.sh
@@ -15,6 +15,6 @@ FILENAME="process-agent-amd64-$PROCESS_AGENT_VERSION"
 WORKSPACE=${WORKSPACE:-$PWD/../}
 agent_path="$WORKSPACE"
 
-s3cmd put --acl-public $agent_path/process-agent s3://${STS_AWS_BUCKET:-stackstate-process-agent-test}/binaries/${CIRCLE_BRANCH:-dirty}/$FILENAME
+aws s3 cp $agent_path/process-agent s3://${STS_AWS_BUCKET:-stackstate-process-agent-test}/binaries/${CIRCLE_BRANCH:-dirty}/$FILENAME --acl public-read
 
 deb-s3 upload --codename ${CIRCLE_BRANCH:-dirty} --bucket ${STS_AWS_BUCKET:-stackstate-process-agent-test} $WORKSPACE/packaging/debian/*.deb


### PR DESCRIPTION
fix(build) Provide builder image based on main stackstate-agent centos6 (glibc 2.12). Use new builder image and cleanup gitlab.yml considering packages are already present in image. Make sure to exit if apply branding fails.