### PR TITLE
STAC-11445: Treat inability to start network tracing as a breaking error

### DIFF
--- a/checks/net_linux.go
+++ b/checks/net_linux.go
@@ -26,8 +26,8 @@ func (c *ConnectionsCheck) Init(cfg *config.AgentConfig, sysInfo *model.SystemIn
 		// Checking whether the current kernel version is supported by the tracer
 		if _, err = tracer.IsTracerSupportedByOS(); err != nil {
 			// err is always returned when false, so the above catches the !ok case as well
-			log.Warnf("network tracer unsupported by OS: %s", err)
-			return
+			log.Errorf("network tracer unsupported by OS: %s", err)
+			os.Exit(1)
 		}
 
 		conf := tracerConfig.DefaultConfig
@@ -42,7 +42,7 @@ func (c *ConnectionsCheck) Init(cfg *config.AgentConfig, sysInfo *model.SystemIn
 		t, err := tracer.NewTracer(conf)
 		if err != nil {
 			log.Errorf("failed to create network tracer: %s", err)
-			return
+			os.Exit(1)
 		}
 
 		c.localTracer = t

--- a/checks/net_windows.go
+++ b/checks/net_windows.go
@@ -9,6 +9,7 @@ import (
 	tracerConfig "github.com/StackVista/tcptracer-bpf/pkg/tracer/config"
 	log "github.com/cihub/seelog"
 	"github.com/patrickmn/go-cache"
+	"os"
 )
 
 // Init initializes a ConnectionsCheck instance.

--- a/checks/net_windows.go
+++ b/checks/net_windows.go
@@ -32,7 +32,7 @@ func (c *ConnectionsCheck) Init(cfg *config.AgentConfig, sysInfo *model.SystemIn
 		t, err := tracer.NewTracer(conf)
 		if err != nil {
 			log.Errorf("failed to create network tracer: %s", err)
-			return
+			os.Exit(1)
 		}
 
 		c.localTracer = t


### PR DESCRIPTION
### Step 1: Link to Jira issue

STAC-11445

### Step 2: Description of changes

Treat inability to run the network tracer as a breaking issue. This is required because of:
- it is good practice to fail hard when we really cannot do something for the user
- on kubernetes sometimes the process agent is restarted so fast that ebpf is still hanging around, in this case we really need kubernetes to try again

### Step 3: Did you add / update tests for your changes in the right area?
- [ ] Unit/Component test		


### Step 4: I'm confident that everything is properly tested:
I got a PO / QA Approval by:
- [ ] Name

### Step 5: Can we ship this feature to production?
- [ ] Yes, I'm proud of my work. Ship it! :ship: