### PR TITLE
Stac-13362 Fix for hitting max connection limit too early

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -127,7 +127,8 @@
     "pkg/tracer/procspy",
   ]
   pruneopts = ""
-  revision = "dd10e1ac736a5bf240ba785c16a6a50a933cb9af"
+  revision = "5da2b312bc80874e491e5b5f108554ef7cd3e12d"
+  version = "v7.0.4"
 
 [[projects]]
   digest = "1:63776251fbaa60062742412a9d2fa1e4b7cd24bcf5527fa9656b314ea8d60913"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -116,7 +116,7 @@
   revision = "4bff1c1cc2aaec39eb753d831d483eaacfb2deda"
 
 [[projects]]
-  digest = "1:9b5c5d2fce797388f49f3da07a023ece39426565cb55e142a45fb311ac3ba613"
+  digest = "1:e117fde63e30a641ac2c92eed0265473732dfd4005c169ce72d23a860d467924"
   name = "github.com/StackVista/tcptracer-bpf"
   packages = [
     "pkg/tracer",
@@ -127,8 +127,7 @@
     "pkg/tracer/procspy",
   ]
   pruneopts = ""
-  revision = "dc2f620ceb15a294cf1cd11ef2fc775e2b62c048"
-  version = "v7.0.3"
+  revision = "dd10e1ac736a5bf240ba785c16a6a50a933cb9af"
 
 [[projects]]
   digest = "1:63776251fbaa60062742412a9d2fa1e4b7cd24bcf5527fa9656b314ea8d60913"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -8,7 +8,7 @@
 
 [[constraint]]
   name = "github.com/StackVista/tcptracer-bpf"
-  revision = "dd10e1ac736a5bf240ba785c16a6a50a933cb9af"
+  version = "7.0.4"
 
 [[constraint]]
   name = "github.com/DataDog/sketches-go"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -8,7 +8,7 @@
 
 [[constraint]]
   name = "github.com/StackVista/tcptracer-bpf"
-  version = "=v7.0.3"
+  revision = "dd10e1ac736a5bf240ba785c16a6a50a933cb9af"
 
 [[constraint]]
   name = "github.com/DataDog/sketches-go"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -8,7 +8,7 @@
 
 [[constraint]]
   name = "github.com/StackVista/tcptracer-bpf"
-  version = "7.0.4"
+  version = "=7.0.4"
 
 [[constraint]]
   name = "github.com/DataDog/sketches-go"

--- a/checks/net_linux.go
+++ b/checks/net_linux.go
@@ -4,6 +4,8 @@ package checks
 
 import (
 	"bytes"
+	"os"
+
 	"github.com/StackVista/stackstate-process-agent/config"
 	"github.com/StackVista/stackstate-process-agent/model"
 	"github.com/StackVista/stackstate-process-agent/net"
@@ -11,7 +13,6 @@ import (
 	tracerConfig "github.com/StackVista/tcptracer-bpf/pkg/tracer/config"
 	log "github.com/cihub/seelog"
 	"github.com/patrickmn/go-cache"
-	"os"
 )
 
 // Init initializes a ConnectionsCheck instance.
@@ -35,7 +36,7 @@ func (c *ConnectionsCheck) Init(cfg *config.AgentConfig, sysInfo *model.SystemIn
 		if proc := os.Getenv("HOST_PROC"); proc != "" {
 			conf.ProcRoot = proc
 		}
-		conf.MaxConnections = cfg.MaxPerMessage
+		conf.MaxConnections = cfg.NetworkTracerMaxConnections
 		conf.BackfillFromProc = cfg.NetworkInitialConnectionsFromProc
 		conf.EnableTracepipeLogging = cfg.NetworkTracer.EbpfDebuglogEnabled
 		conf.HttpMetricConfig = *cfg.NetworkTracer.HTTPMetrics

--- a/checks/net_windows.go
+++ b/checks/net_windows.go
@@ -27,7 +27,7 @@ func (c *ConnectionsCheck) Init(cfg *config.AgentConfig, sysInfo *model.SystemIn
 		}
 
 		conf := tracerConfig.DefaultConfig
-		conf.MaxConnections = cfg.MaxPerMessage
+		conf.MaxConnections = cfg.NetworkTracerMaxConnections
 
 		t, err := tracer.NewTracer(conf)
 		if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -748,6 +748,10 @@ func mergeEnvironmentVariables(c *AgentConfig) *AgentConfig {
 		c.MaxConnectionsPerMessage = maxConnections
 	}
 
+	if ok, _ := isAffirmative(os.Getenv("STS_EBPF_DEBUG_LOG_ENABLED")); ok {
+		c.NetworkTracer.EbpfDebuglogEnabled = true
+	}
+
 	if v, err := strconv.Atoi(os.Getenv("STS_NETWORK_TRACER_INIT_RETRY_AMOUNT")); err == nil {
 		c.NetworkTracerInitRetryAmount = v
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -738,6 +738,16 @@ func mergeEnvironmentVariables(c *AgentConfig) *AgentConfig {
 		c.NetworkTracerMaxConnections = maxConnections
 	}
 
+	if v := os.Getenv("STS_MAX_PROCESSES_PER_MESSAGE"); v != "" {
+		maxConnections, _ := strconv.Atoi(v)
+		c.MaxPerMessage = maxConnections
+	}
+
+	if v := os.Getenv("STS_MAX_CONNECTIONS_PER_MESSAGE"); v != "" {
+		maxConnections, _ := strconv.Atoi(v)
+		c.MaxConnectionsPerMessage = maxConnections
+	}
+
 	if v, err := strconv.Atoi(os.Getenv("STS_NETWORK_TRACER_INIT_RETRY_AMOUNT")); err == nil {
 		c.NetworkTracerInitRetryAmount = v
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -5,7 +5,6 @@ package config
 import (
 	"bytes"
 	"fmt"
-	tracerconfig "github.com/StackVista/tcptracer-bpf/pkg/tracer/config"
 	"net"
 	"net/http"
 	"net/url"
@@ -15,6 +14,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	tracerconfig "github.com/StackVista/tcptracer-bpf/pkg/tracer/config"
 
 	"github.com/StackVista/stackstate-process-agent/util"
 
@@ -74,25 +75,26 @@ type APIEndpoint struct {
 // AgentConfig is the global config for the process-agent. This information
 // is sourced from config files and the environment variables.
 type AgentConfig struct {
-	Enabled       bool
-	HostName      string
-	APIEndpoints  []APIEndpoint
-	LogFile       string
-	LogLevel      string
-	LogToConsole  bool
-	QueueSize     int
-	Blacklist     []*regexp.Regexp
-	Scrubber      *DataScrubber
-	MaxProcFDs    int
-	MaxPerMessage int
-	AllowRealTime bool
-	Transport     *http.Transport `json:"-"`
-	Logger        *LoggerConfig
-	DDAgentPy     string
-	DDAgentBin    string
-	DDAgentPyEnv  []string
-	StatsdHost    string
-	StatsdPort    int
+	Enabled                  bool
+	HostName                 string
+	APIEndpoints             []APIEndpoint
+	LogFile                  string
+	LogLevel                 string
+	LogToConsole             bool
+	QueueSize                int
+	Blacklist                []*regexp.Regexp
+	Scrubber                 *DataScrubber
+	MaxProcFDs               int
+	MaxPerMessage            int
+	MaxConnectionsPerMessage int
+	AllowRealTime            bool
+	Transport                *http.Transport `json:"-"`
+	Logger                   *LoggerConfig
+	DDAgentPy                string
+	DDAgentBin               string
+	DDAgentPyEnv             []string
+	StatsdHost               string
+	StatsdPort               int
 
 	// Process Cache Expiration, In Minutes
 	ProcessCacheDurationMin time.Duration
@@ -132,6 +134,8 @@ type AgentConfig struct {
 	NetworkTracerInitRetryDuration    time.Duration
 	NetworkTracerInitRetryAmount      int
 	NetworkTracer                     *NetworkTracerConfig
+	// Maximum connections the network tracer keeps track of
+	NetworkTracerMaxConnections int
 
 	// Check config
 	EnabledChecks  []string
@@ -199,17 +203,18 @@ func NewDefaultAgentConfig() *AgentConfig {
 	canAccessContainers := err == nil
 
 	ac := &AgentConfig{
-		Enabled:       canAccessContainers, // We'll always run inside of a container.
-		APIEndpoints:  []APIEndpoint{{Endpoint: u}},
-		LogFile:       defaultLogFilePath,
-		LogLevel:      "info",
-		LogToConsole:  false,
-		QueueSize:     20,
-		MaxProcFDs:    200,
-		MaxPerMessage: 2000,
-		AllowRealTime: true,
-		HostName:      "",
-		Transport:     NewDefaultTransport(),
+		Enabled:                  canAccessContainers, // We'll always run inside of a container.
+		APIEndpoints:             []APIEndpoint{{Endpoint: u}},
+		LogFile:                  defaultLogFilePath,
+		LogLevel:                 "info",
+		LogToConsole:             false,
+		QueueSize:                20,
+		MaxProcFDs:               200,
+		MaxPerMessage:            maxMessageBatch,
+		MaxConnectionsPerMessage: 100,
+		AllowRealTime:            true,
+		HostName:                 "",
+		Transport:                NewDefaultTransport(),
 
 		// Statsd for internal instrumentation
 		StatsdHost: "127.0.0.1",
@@ -248,6 +253,7 @@ func NewDefaultAgentConfig() *AgentConfig {
 		EnableNetworkTracing:              false,
 		EnableLocalNetworkTracer:          true,
 		NetworkInitialConnectionsFromProc: true,
+		NetworkTracerMaxConnections:       10000,
 		NetworkTracerSocketPath:           defaultNetworkTracerSocketPath,
 		NetworkTracerLogFile:              defaultNetworkLogFilePath,
 		NetworkTracerInitRetryDuration:    5 * time.Second,
@@ -725,6 +731,11 @@ func mergeEnvironmentVariables(c *AgentConfig) *AgentConfig {
 	if v := os.Getenv("STS_NETWORK_TRACER_INIT_RETRY_DURATION_SEC"); v != "" {
 		durationS, _ := strconv.Atoi(v)
 		c.NetworkTracerInitRetryDuration = time.Duration(durationS) * time.Second
+	}
+
+	if v := os.Getenv("STS_NETWORK_TRACER_MAX_CONNECTIONS"); v != "" {
+		maxConnections, _ := strconv.Atoi(v)
+		c.NetworkTracerMaxConnections = maxConnections
 	}
 
 	if v, err := strconv.Atoi(os.Getenv("STS_NETWORK_TRACER_INIT_RETRY_AMOUNT")); err == nil {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -988,6 +988,26 @@ func TestProxyEnv(t *testing.T) {
 	}
 }
 
+func TestEnvOverrides(t *testing.T) {
+	assert := assert.New(t)
+	os.Setenv("STS_NETWORK_TRACER_MAX_CONNECTIONS", "500")
+	os.Setenv("STS_CLUSTER_NAME", "test-override")
+	os.Setenv("STS_MAX_PROCESSES_PER_MESSAGE", "501")
+	os.Setenv("STS_MAX_CONNECTIONS_PER_MESSAGE", "502")
+	os.Setenv("STS_PROTOCOL_INSPECTION_ENABLED", "false")
+	os.Setenv("DD_ENABLE_NETWORK_TRACING", "false")
+	os.Setenv("STS_EBPF_DEBUG_LOG_ENABLED", "true")
+
+	agentConfig, _ := NewAgentConfig(nil, nil, nil)
+
+	assert.Equal(500, agentConfig.NetworkTracerMaxConnections)
+	assert.Equal(501, agentConfig.MaxPerMessage)
+	assert.Equal(502, agentConfig.MaxConnectionsPerMessage)
+	assert.Equal(false, agentConfig.NetworkTracer.EnableProtocolInspection)
+	assert.Equal(false, agentConfig.EnableNetworkTracing)
+	assert.Equal(true, agentConfig.NetworkTracer.EbpfDebuglogEnabled)
+}
+
 func getURL(f *ini.File) (*url.URL, error) {
 	conf := File{
 		f,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -995,7 +995,7 @@ func TestEnvOverrides(t *testing.T) {
 	os.Setenv("STS_MAX_PROCESSES_PER_MESSAGE", "501")
 	os.Setenv("STS_MAX_CONNECTIONS_PER_MESSAGE", "502")
 	os.Setenv("STS_PROTOCOL_INSPECTION_ENABLED", "false")
-	os.Setenv("DD_ENABLE_NETWORK_TRACING", "false")
+	os.Setenv("DD_NETWORK_TRACING_ENABLED", "true")
 	os.Setenv("STS_EBPF_DEBUG_LOG_ENABLED", "true")
 
 	agentConfig, _ := NewAgentConfig(nil, nil, nil)
@@ -1004,7 +1004,7 @@ func TestEnvOverrides(t *testing.T) {
 	assert.Equal(501, agentConfig.MaxPerMessage)
 	assert.Equal(502, agentConfig.MaxConnectionsPerMessage)
 	assert.Equal(false, agentConfig.NetworkTracer.EnableProtocolInspection)
-	assert.Equal(false, agentConfig.EnableNetworkTracing)
+	assert.Equal(true, agentConfig.EnableNetworkTracing)
 	assert.Equal(true, agentConfig.NetworkTracer.EbpfDebuglogEnabled)
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2,8 +2,6 @@ package config
 
 import (
 	"fmt"
-	"github.com/StackVista/stackstate-process-agent/util"
-	"github.com/StackVista/tcptracer-bpf/pkg/tracer/config"
 	"net/http"
 	"net/url"
 	"os"
@@ -14,6 +12,9 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/StackVista/stackstate-process-agent/util"
+	"github.com/StackVista/tcptracer-bpf/pkg/tracer/config"
 
 	"github.com/DataDog/gopsutil/process"
 	ddconfig "github.com/StackVista/stackstate-agent/pkg/config"
@@ -866,6 +867,7 @@ func TestStackStateNetworkConfigFromMainAgentConfig(t *testing.T) {
 	assert.Equal(8*time.Second, agentConfig.CheckIntervals["container"])
 	assert.Equal(30*time.Second, agentConfig.CheckIntervals["process"])
 	assert.Equal(true, agentConfig.NetworkInitialConnectionsFromProc)
+	assert.Equal(10000, agentConfig.NetworkTracerMaxConnections)
 	assert.Equal(append(processChecks, "connections"), agentConfig.EnabledChecks)
 	assert.Equal(10*time.Minute, agentConfig.NetworkRelationCacheDurationMin)
 	assert.Equal(15*time.Minute, agentConfig.ProcessCacheDurationMin)
@@ -881,6 +883,7 @@ func TestStackStateNetworkConfigWithHttpMetricsOptions(t *testing.T) {
 	err := yaml.Unmarshal(
 		[]byte(`
 network_tracer_config:
+  max_connections: 2000
   network_tracing_enabled: 'true'
   protocol_inspection_enabled: 'true'
   ebpf_debuglog_enabled: 'true'
@@ -897,6 +900,7 @@ network_tracer_config:
 	assert.Equal(true, agentConfig.NetworkTracer.EnableProtocolInspection)
 	assert.Equal(true, agentConfig.NetworkTracer.EbpfDebuglogEnabled)
 	assert.Equal(config.CollapsingHighest, agentConfig.NetworkTracer.HTTPMetrics.SketchType)
+	assert.Equal(2000, agentConfig.NetworkTracerMaxConnections)
 	assert.Equal(42, agentConfig.NetworkTracer.HTTPMetrics.MaxNumBins)
 	assert.Equal(0.123, agentConfig.NetworkTracer.HTTPMetrics.Accuracy)
 }


### PR DESCRIPTION
### Step 1: Link to Jira issue
https://stackstate.atlassian.net/browse/STAC-13362

### Step 2: Description of changes
* Upgrade to epbf trace lib that only logs once per message
* Separate configuration for `maxInFlight` for tracer from `maxConnectionsPerMessage` for agent
* Re-introduce batching for connections

### Step 3: Did you add / update tests for your changes in the right area?
- [ ] Unit/Component test		


### Step 4: I'm confident that everything is properly tested:
I got a PO / QA Approval by:
- [ ] Name

### Step 5: Can we ship this feature to production?
- [ ] Yes, I'm proud of my work. Ship it! :ship: