### PR TITLE
Fix connections send/recv statistics

### DIFF
--- a/checks/net_cache.go
+++ b/checks/net_cache.go
@@ -7,11 +7,13 @@ import (
 	"time"
 )
 
+// NetworkRelationCache is used to track age of network relations and to keep metrics for connection for calculating rates
 type NetworkRelationCache struct {
 	cache            *cache.Cache
 	minCacheDuration time.Duration
 }
 
+// NewNetworkRelationCache create network relation cache with specified minimum duration for stored items
 func NewNetworkRelationCache(minCacheDuration time.Duration) *NetworkRelationCache {
 	relationCache := cache.New(minCacheDuration, minCacheDuration)
 	return &NetworkRelationCache{
@@ -38,8 +40,9 @@ type NetworkRelationCacheItem struct {
 	connectionMetrics *cache.Cache
 }
 
-func (nrci *NetworkRelationCacheItem) GetMetrics(connId common.ConnTuple) (*ConnectionMetrics, bool) {
-	result, found := nrci.connectionMetrics.Get(fmt.Sprintf("%v", connId))
+// GetMetrics return metrics for particular network connection (not relation)
+func (nrci *NetworkRelationCacheItem) GetMetrics(connID common.ConnTuple) (*ConnectionMetrics, bool) {
+	result, found := nrci.connectionMetrics.Get(fmt.Sprintf("%v", connID))
 	if found {
 		return result.(*ConnectionMetrics), true
 	}
@@ -95,13 +98,12 @@ func (nrc *NetworkRelationCache) PutNetworkRelationCache(relationID string, conn
 	return cachedRelation
 }
 
+// Flush removes all items from cache
 func (nrc *NetworkRelationCache) Flush() {
 	nrc.cache.Flush()
-	for _, item := range nrc.cache.Items() {
-		item.Object.(*NetworkRelationCacheItem).connectionMetrics.Flush()
-	}
 }
 
+// ItemCount returns count of network relations in cache
 func (nrc *NetworkRelationCache) ItemCount() int {
 	return nrc.cache.ItemCount()
 }

--- a/checks/net_cache.go
+++ b/checks/net_cache.go
@@ -1,62 +1,107 @@
 package checks
 
 import (
+	"fmt"
 	"github.com/StackVista/tcptracer-bpf/pkg/tracer/common"
 	"github.com/patrickmn/go-cache"
 	"time"
 )
 
-// ConnectionMetrics is used to keep state of the previous send and received bytes so that we can calculate transfer rate
-type ConnectionMetrics struct {
-	SendBytes uint64
-	RecvBytes uint64
+type NetworkRelationCache struct {
+	cache            *cache.Cache
+	minCacheDuration time.Duration
 }
 
-// NetworkRelationCache is used as the struct in the cache for all seen network relations
+func NewNetworkRelationCache(minCacheDuration time.Duration) *NetworkRelationCache {
+	relationCache := cache.New(minCacheDuration, minCacheDuration)
+	return &NetworkRelationCache{
+		cache: relationCache,
+	}
+}
+
+// ConnectionMetrics is used to keep state of the previous send and received bytes so that we can calculate transfer rate
+type ConnectionMetrics struct {
+	LastObserved int64
+	SendBytes    uint64
+	RecvBytes    uint64
+}
+
+// NetworkRelationCacheItem is used as the struct in the cache for all seen network relations
 // The Short-Lived Relations is used to filter out network relations that are observed for less than x seconds, with the default being 60 seconds.
 // Short-Lived network relations are defined as network connections that do not occur frequently between processes / services.
 // Multiple short-lived connections between the same processes / services are considered a Long-Lived network relation,
 // while a once-off network connection is filtered out and not reported to StackState.
-type NetworkRelationCache struct {
-	ConnectionMetrics ConnectionMetrics
+// This is done by removing source port from cache key in CreateNetworkRelationIdentifier & createRelationIdentifier in checks/net_common.go
+type NetworkRelationCacheItem struct {
 	FirstObserved     int64
 	LastObserved      int64
+	connectionMetrics *cache.Cache
 }
 
-// IsNetworkRelationCached checks to see if this relationID is present in the NetworkRelationCache
-func IsNetworkRelationCached(c *cache.Cache, relationID string) (*NetworkRelationCache, bool) {
-	cPointer, found := c.Get(relationID)
+func (nrci *NetworkRelationCacheItem) GetMetrics(connId common.ConnTuple) (*ConnectionMetrics, bool) {
+	result, found := nrci.connectionMetrics.Get(fmt.Sprintf("%v", connId))
 	if found {
-		return cPointer.(*NetworkRelationCache), true
+		return result.(*ConnectionMetrics), true
 	}
-
 	return nil, false
 }
 
-// PutNetworkRelationCache inserts / updates the NetworkRelationCache for relationID
-func PutNetworkRelationCache(c *cache.Cache, relationID string, connStats common.ConnectionStats) *NetworkRelationCache {
-	var cachedRelation *NetworkRelationCache
+// IsNetworkRelationCached checks to see if this relationID is present in the NetworkRelationCacheItem
+func (nrc *NetworkRelationCache) IsNetworkRelationCached(relationID string) (*NetworkRelationCacheItem, bool) {
+	cPointer, found := nrc.cache.Get(relationID)
+	if found {
+		return cPointer.(*NetworkRelationCacheItem), true
+	}
+	return nil, false
+}
+
+// PutNetworkRelationCache inserts / updates the NetworkRelationCacheItem for relationID
+func (nrc *NetworkRelationCache) PutNetworkRelationCache(relationID string, connStats common.ConnectionStats) *NetworkRelationCacheItem {
+	var cachedRelation *NetworkRelationCacheItem
 	nowUnix := time.Now().Unix()
 
-	cPointer, found := c.Get(relationID)
+	cPointer, found := nrc.cache.Get(relationID)
 	if found {
-		cachedRelation = cPointer.(*NetworkRelationCache)
-		cachedRelation.ConnectionMetrics = ConnectionMetrics{
-			SendBytes: connStats.SendBytes,
-			RecvBytes: connStats.RecvBytes,
-		}
+		cachedRelation = cPointer.(*NetworkRelationCacheItem)
+		cachedRelation.connectionMetrics.Set(
+			fmt.Sprintf("%v", connStats.GetConnection()),
+			&ConnectionMetrics{
+				LastObserved: nowUnix,
+				SendBytes:    connStats.SendBytes,
+				RecvBytes:    connStats.RecvBytes,
+			},
+			cache.DefaultExpiration,
+		)
 		cachedRelation.LastObserved = nowUnix
 	} else {
-		cachedRelation = &NetworkRelationCache{
-			ConnectionMetrics: ConnectionMetrics{
-				SendBytes: connStats.SendBytes,
-				RecvBytes: connStats.RecvBytes,
+		connCache := cache.New(nrc.minCacheDuration, nrc.minCacheDuration)
+		connCache.Set(
+			fmt.Sprintf("%v", connStats.GetConnection()),
+			&ConnectionMetrics{
+				LastObserved: nowUnix,
+				SendBytes:    connStats.SendBytes,
+				RecvBytes:    connStats.RecvBytes,
 			},
-			FirstObserved: nowUnix,
-			LastObserved:  nowUnix,
+			cache.DefaultExpiration,
+		)
+		cachedRelation = &NetworkRelationCacheItem{
+			connectionMetrics: connCache,
+			FirstObserved:     nowUnix,
+			LastObserved:      nowUnix,
 		}
 	}
 
-	c.Set(relationID, cachedRelation, cache.DefaultExpiration)
+	nrc.cache.Set(relationID, cachedRelation, cache.DefaultExpiration)
 	return cachedRelation
+}
+
+func (nrc *NetworkRelationCache) Flush() {
+	nrc.cache.Flush()
+	for _, item := range nrc.cache.Items() {
+		item.Object.(*NetworkRelationCacheItem).connectionMetrics.Flush()
+	}
+}
+
+func (nrc *NetworkRelationCache) ItemCount() int {
+	return nrc.cache.ItemCount()
 }

--- a/checks/net_common.go
+++ b/checks/net_common.go
@@ -8,6 +8,7 @@ import (
 	tracerConfig "github.com/StackVista/tcptracer-bpf/pkg/tracer/config"
 	log "github.com/cihub/seelog"
 	"net"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -37,7 +38,7 @@ func endpointKey(e *endpointID) string {
 	}
 
 	if e.Endpoint != nil {
-		values = append(values, string(e.Endpoint.Port))
+		values = append(values, strconv.Itoa(int(e.Endpoint.Port)))
 	}
 
 	return strings.Join(values, ":")

--- a/checks/net_linux.go
+++ b/checks/net_linux.go
@@ -12,7 +12,6 @@ import (
 	"github.com/StackVista/tcptracer-bpf/pkg/tracer"
 	tracerConfig "github.com/StackVista/tcptracer-bpf/pkg/tracer/config"
 	log "github.com/cihub/seelog"
-	"github.com/patrickmn/go-cache"
 )
 
 // Init initializes a ConnectionsCheck instance.
@@ -56,7 +55,7 @@ func (c *ConnectionsCheck) Init(cfg *config.AgentConfig, sysInfo *model.SystemIn
 		net.GetRemoteNetworkTracerUtil()
 	}
 
-	c.cache = cache.New(cfg.NetworkRelationCacheDurationMin, cfg.NetworkRelationCacheDurationMin)
+	c.cache = NewNetworkRelationCache(cfg.NetworkRelationCacheDurationMin)
 
 	c.buf = new(bytes.Buffer)
 }

--- a/checks/net_test.go
+++ b/checks/net_test.go
@@ -121,7 +121,7 @@ func TestFilterConnectionsByProcess(t *testing.T) {
 	now := time.Now()
 	c := &ConnectionsCheck{
 		buf:   new(bytes.Buffer),
-		cache: cache.New(cfg.NetworkRelationCacheDurationMin, cfg.NetworkRelationCacheDurationMin),
+		cache: NewNetworkRelationCache(cfg.NetworkRelationCacheDurationMin),
 	}
 
 	// create the connection stats
@@ -146,7 +146,7 @@ func TestFilterConnectionsByProcess(t *testing.T) {
 		// pid 4 filtered by process blacklisting, so we expect no connections for pid 4
 	}
 
-	connections := c.formatConnections(cfg, connStats, now.Add(-15*time.Second))
+	connections := c.formatConnections(cfg, connStats, 15*time.Second)
 
 	assert.Len(t, connections, 3)
 
@@ -167,7 +167,7 @@ func TestNetworkConnectionNamespaceKubernetes(t *testing.T) {
 
 	c := &ConnectionsCheck{
 		buf:   new(bytes.Buffer),
-		cache: cache.New(cfg.NetworkRelationCacheDurationMin, cfg.NetworkRelationCacheDurationMin),
+		cache: NewNetworkRelationCache(cfg.NetworkRelationCacheDurationMin),
 	}
 
 	// create the connection stats
@@ -193,7 +193,7 @@ func TestNetworkConnectionNamespaceKubernetes(t *testing.T) {
 		4: {Pid: 4, CreateTime: now.Add(-5 * time.Minute).Unix()},
 	}
 
-	connections := c.formatConnections(cfg, connStats, now.Add(-15*time.Second))
+	connections := c.formatConnections(cfg, connStats, 15*time.Second)
 
 	assert.Len(t, connections, 4)
 	for _, c := range connections {
@@ -212,7 +212,7 @@ func TestRelationCache(t *testing.T) {
 	now := time.Now()
 	c := &ConnectionsCheck{
 		buf:   new(bytes.Buffer),
-		cache: cache.New(cfg.NetworkRelationCacheDurationMin, cfg.NetworkRelationCacheDurationMin),
+		cache: NewNetworkRelationCache(cfg.NetworkRelationCacheDurationMin),
 	}
 
 	// create the connection stats
@@ -235,7 +235,7 @@ func TestRelationCache(t *testing.T) {
 	assert.Zero(t, c.cache.ItemCount(), "Cache should be empty before running")
 
 	// first run on an empty cache; expect no process, but cache should be filled in now.
-	firstRun := c.formatConnections(cfg, connStats, now.Add(-15*time.Second))
+	firstRun := c.formatConnections(cfg, connStats, 15*time.Second)
 	assert.Zero(t, len(firstRun), "Connections should be empty when the cache is not present")
 	assert.Equal(t, 4, c.cache.ItemCount(), "Cache should contain 4 elements")
 
@@ -243,13 +243,13 @@ func TestRelationCache(t *testing.T) {
 	time.Sleep(cfg.ShortLivedNetworkRelationQualifierSecs)
 
 	// second run with filled in cache; expect all processes.
-	secondRun := c.formatConnections(cfg, connStats, now.Add(-10*time.Second))
+	secondRun := c.formatConnections(cfg, connStats, 10*time.Second)
 	assert.Equal(t, 4, len(secondRun), "Connections should contain 4 elements")
 	assert.Equal(t, 4, c.cache.ItemCount(), "Cache should contain 4 elements")
 
 	// delete last connection from the connection stats slice, expect it to be excluded from the connection list, but not the cache
 	connStats = connStats[:len(connStats)-1]
-	thirdRun := c.formatConnections(cfg, connStats, now.Add(-5*time.Second))
+	thirdRun := c.formatConnections(cfg, connStats, 5*time.Second)
 	assert.Equal(t, 3, len(thirdRun), "Connections should contain 3 elements")
 	assert.Equal(t, 4, c.cache.ItemCount(), "Cache should contain 4 elements")
 
@@ -276,14 +276,14 @@ func TestRelationShortLivedFiltering(t *testing.T) {
 
 	for _, tc := range []struct {
 		name                             string
-		prepCache                        func(c *cache.Cache)
+		prepCache                        func(c *NetworkRelationCache)
 		expected                         bool
 		networkRelationShortLivedEnabled bool
 	}{
 		{
 			name: fmt.Sprintf("Should not filter a relation that has been observed longer than the short-lived qualifier "+
 				"duration: %d", cfg.ShortLivedProcessQualifierSecs),
-			prepCache: func(c *cache.Cache) {
+			prepCache: func(c *NetworkRelationCache) {
 				err := fillNetworkRelationCache(cfg.HostName, c, connStats[0], lastRun.Add(-5*time.Minute).Unix(), lastRun.Unix())
 				assert.NoError(t, err)
 			},
@@ -293,7 +293,7 @@ func TestRelationShortLivedFiltering(t *testing.T) {
 		{
 			name: fmt.Sprintf("Should not filter a similar relation that has been observed longer than the short-lived qualifier "+
 				"duration: %d", cfg.ShortLivedProcessQualifierSecs),
-			prepCache: func(c *cache.Cache) {
+			prepCache: func(c *NetworkRelationCache) {
 				// use a "similar" connection; thus we observed a similar connection in the previous run
 				conn := makeConnectionStats(1, "10.0.0.1", "10.0.0.2", 54321, 8080)
 				err := fillNetworkRelationCache(cfg.HostName, c, conn, lastRun.Add(-5*time.Minute).Unix(), lastRun.Unix())
@@ -305,7 +305,7 @@ func TestRelationShortLivedFiltering(t *testing.T) {
 		{
 			name: fmt.Sprintf("Should filter a relation that has not been observed longer than the short-lived qualifier "+
 				"duration: %d", cfg.ShortLivedProcessQualifierSecs),
-			prepCache: func(c *cache.Cache) {
+			prepCache: func(c *NetworkRelationCache) {
 				err := fillNetworkRelationCache(cfg.HostName, c, connStats[0], lastRun.Add(-5*time.Second).Unix(), lastRun.Unix())
 				assert.NoError(t, err)
 			},
@@ -314,7 +314,7 @@ func TestRelationShortLivedFiltering(t *testing.T) {
 		},
 		{
 			name: fmt.Sprintf("Should not filter a relation when the networkRelationShortLivedEnabled is set to false"),
-			prepCache: func(c *cache.Cache) {
+			prepCache: func(c *NetworkRelationCache) {
 				err := fillNetworkRelationCache(cfg.HostName, c, connStats[0], lastRun.Add(-5*time.Second).Unix(), lastRun.Unix())
 				assert.NoError(t, err)
 			},
@@ -329,12 +329,12 @@ func TestRelationShortLivedFiltering(t *testing.T) {
 			// Connections Check
 			c := &ConnectionsCheck{
 				buf:   new(bytes.Buffer),
-				cache: cache.New(cfg.NetworkRelationCacheDurationMin, cfg.NetworkRelationCacheDurationMin),
+				cache: NewNetworkRelationCache(cfg.NetworkRelationCacheDurationMin),
 			}
 			// fill in the relation cache
 			tc.prepCache(c.cache)
 
-			connections := c.formatConnections(cfg, connStats, lastRun)
+			connections := c.formatConnections(cfg, connStats, time.Now().Sub(lastRun))
 			var rIDs []string
 			for _, conn := range connections {
 				rIDs = append(rIDs, conn.ConnectionIdentifier)
@@ -366,20 +366,28 @@ func TestFormatNamespace(t *testing.T) {
 	assert.Equal(t, "c:h", formatNamespace("c", "h", makeConnectionStatsNoNs(1, "127.0.0.1", "127.0.0.1", 12345, 8080)))
 }
 
-func fillNetworkRelationCache(hostname string, c *cache.Cache, conn common.ConnectionStats, firstObserved, lastObserved int64) error {
+func fillNetworkRelationCache(hostname string, c *NetworkRelationCache, conn common.ConnectionStats, firstObserved, lastObserved int64) error {
 	relationID, err := CreateNetworkRelationIdentifier(hostname, conn)
 	if err != nil {
 		return err
 	}
-	cachedRelation := &NetworkRelationCache{
-		ConnectionMetrics: ConnectionMetrics{
+
+	metricsCache := cache.New(c.minCacheDuration, c.minCacheDuration)
+	metricsCache.Set(
+		fmt.Sprintf("%v", conn.GetConnection()),
+		&ConnectionMetrics{
 			SendBytes: conn.SendBytes,
 			RecvBytes: conn.RecvBytes,
 		},
-		FirstObserved: firstObserved,
-		LastObserved:  lastObserved,
+		cache.DefaultExpiration,
+	)
+
+	cachedRelation := &NetworkRelationCacheItem{
+		connectionMetrics: metricsCache,
+		FirstObserved:     firstObserved,
+		LastObserved:      lastObserved,
 	}
-	c.Set(relationID, cachedRelation, cache.DefaultExpiration)
+	c.cache.Set(relationID, cachedRelation, cache.DefaultExpiration)
 	return nil
 }
 

--- a/checks/net_test.go
+++ b/checks/net_test.go
@@ -262,7 +262,6 @@ func TestRelationCache(t *testing.T) {
 	// wait for cfg.NetworkRelationCacheDurationMin + a 250 Millisecond buffer to allow the cache expiration to complete
 	time.Sleep(cfg.NetworkRelationCacheDurationMin + 250*time.Millisecond)
 	assert.Zero(t, c.cache.ItemCount(), "Cache should be empty again")
-	//}
 
 	c.cache.Flush()
 }
@@ -289,24 +288,24 @@ const (
 	PID2CONN1SEND3 = uint64(132400)
 	PID2CONN1RECV3 = uint64(213200)
 
-	TIME1 = float32(10)
-	PID1CONN1SEND2EXPECT = float32(PID1CONN1SEND2 - PID1CONN1SEND1)/TIME1
-	PID1CONN2SEND2EXPECT = float32(PID1CONN2SEND2 - PID1CONN2SEND1)/TIME1
-	PID2CONN1SEND2EXPECT = float32(PID2CONN1SEND2 - PID2CONN1SEND1)/TIME1
+	TIME1                = float32(10)
+	PID1CONN1SEND2EXPECT = float32(PID1CONN1SEND2-PID1CONN1SEND1) / TIME1
+	PID1CONN2SEND2EXPECT = float32(PID1CONN2SEND2-PID1CONN2SEND1) / TIME1
+	PID2CONN1SEND2EXPECT = float32(PID2CONN1SEND2-PID2CONN1SEND1) / TIME1
 
-	PID1CONN1RECV2EXPECT = float32(PID1CONN1RECV2 - PID1CONN1RECV1)/TIME1
-	PID1CONN2RECV2EXPECT = float32(PID1CONN2RECV2 - PID1CONN2RECV1)/TIME1
-	PID2CONN1RECV2EXPECT = float32(PID2CONN1RECV2 - PID2CONN1RECV1)/TIME1
+	PID1CONN1RECV2EXPECT = float32(PID1CONN1RECV2-PID1CONN1RECV1) / TIME1
+	PID1CONN2RECV2EXPECT = float32(PID1CONN2RECV2-PID1CONN2RECV1) / TIME1
+	PID2CONN1RECV2EXPECT = float32(PID2CONN1RECV2-PID2CONN1RECV1) / TIME1
 
-	TIME2 = float32(100)
-	PID1CONN1SEND3EXPECT = float32(PID1CONN1SEND3 - PID1CONN1SEND2)/TIME2
-	PID1CONN2SEND3EXPECT = float32(PID1CONN2SEND3 - PID1CONN2SEND2)/TIME2
-	PID2CONN1SEND3EXPECT = float32(PID2CONN1SEND3 - PID2CONN1SEND2)/TIME2
-	
-	TIME3 = float32(5)
-	PID1CONN1RECV3EXPECT = float32(PID1CONN1RECV3 - PID1CONN1RECV2)/TIME3
-	PID1CONN2RECV3EXPECT = float32(PID1CONN2RECV3 - PID1CONN2RECV2)/TIME3
-	PID2CONN1RECV3EXPECT = float32(PID2CONN1RECV3 - PID2CONN1RECV2)/TIME3
+	TIME2                = float32(100)
+	PID1CONN1SEND3EXPECT = float32(PID1CONN1SEND3-PID1CONN1SEND2) / TIME2
+	PID1CONN2SEND3EXPECT = float32(PID1CONN2SEND3-PID1CONN2SEND2) / TIME2
+	PID2CONN1SEND3EXPECT = float32(PID2CONN1SEND3-PID2CONN1SEND2) / TIME2
+
+	TIME3                = float32(5)
+	PID1CONN1RECV3EXPECT = float32(PID1CONN1RECV3-PID1CONN1RECV2) / TIME3
+	PID1CONN2RECV3EXPECT = float32(PID1CONN2RECV3-PID1CONN2RECV2) / TIME3
+	PID2CONN1RECV3EXPECT = float32(PID2CONN1RECV3-PID2CONN1RECV2) / TIME3
 )
 
 func TestRelationCacheOrdering(t *testing.T) {
@@ -328,9 +327,9 @@ func TestRelationCacheOrdering(t *testing.T) {
 		makeConnectionStats(3, "10.0.0.1", "10.0.0.4", 12348, 8080),
 	}
 
-	connStats[0] = amendConnectionStats(connStats[0], PID1CONN1SEND1,PID1CONN1RECV1)
-	connStats[1] = amendConnectionStats(connStats[1], PID1CONN2SEND1,PID1CONN2RECV1)
-	connStats[2] = amendConnectionStats(connStats[2], PID2CONN1SEND1,PID2CONN1RECV1)
+	connStats[0] = amendConnectionStats(connStats[0], PID1CONN1SEND1, PID1CONN1RECV1)
+	connStats[1] = amendConnectionStats(connStats[1], PID1CONN2SEND1, PID1CONN2RECV1)
+	connStats[2] = amendConnectionStats(connStats[2], PID2CONN1SEND1, PID2CONN1RECV1)
 
 	// fill in the procs in the lastProcState map to get process create time for the connection mapping
 	Process.lastProcState = map[int32]*model.Process{
@@ -343,9 +342,9 @@ func TestRelationCacheOrdering(t *testing.T) {
 	// first run on an empty cache; expect no process, but cache should be filled in now.
 	c.formatConnections(cfg, connStats, 15*time.Second)
 
-	connStats[0] = amendConnectionStats(connStats[0], PID1CONN1SEND2,PID1CONN1RECV2)
-	connStats[1] = amendConnectionStats(connStats[1], PID1CONN2SEND2,PID1CONN2RECV2)
-	connStats[2] = amendConnectionStats(connStats[2], PID2CONN1SEND2,PID2CONN1RECV2)
+	connStats[0] = amendConnectionStats(connStats[0], PID1CONN1SEND2, PID1CONN1RECV2)
+	connStats[1] = amendConnectionStats(connStats[1], PID1CONN2SEND2, PID1CONN2RECV2)
+	connStats[2] = amendConnectionStats(connStats[2], PID2CONN1SEND2, PID2CONN1RECV2)
 
 	// wait for cfg.ShortLivedNetworkRelationQualifierSecs duration
 	time.Sleep(cfg.ShortLivedNetworkRelationQualifierSecs)
@@ -361,9 +360,9 @@ func TestRelationCacheOrdering(t *testing.T) {
 	assert.Equal(t, PID1CONN2RECV2EXPECT, secondRun[1].BytesReceivedPerSecond, "BytesReceivedPerSecond")
 	assert.Equal(t, PID2CONN1RECV2EXPECT, secondRun[2].BytesReceivedPerSecond, "BytesReceivedPerSecond")
 
-	connStats[0] = amendConnectionStats(connStats[0], PID1CONN1SEND3,PID1CONN1RECV3)
-	connStats[1] = amendConnectionStats(connStats[1], PID1CONN2SEND3,PID1CONN2RECV3)
-	connStats[2] = amendConnectionStats(connStats[2], PID2CONN1SEND3,PID2CONN1RECV3)
+	connStats[0] = amendConnectionStats(connStats[0], PID1CONN1SEND3, PID1CONN1RECV3)
+	connStats[1] = amendConnectionStats(connStats[1], PID1CONN2SEND3, PID1CONN2RECV3)
+	connStats[2] = amendConnectionStats(connStats[2], PID2CONN1SEND3, PID2CONN1RECV3)
 
 	thirdRun := c.formatConnections(cfg, connStats, 5*time.Second)
 
@@ -374,9 +373,6 @@ func TestRelationCacheOrdering(t *testing.T) {
 	assert.Equal(t, PID1CONN1RECV3EXPECT, thirdRun[0].BytesReceivedPerSecond, "BytesReceivedPerSecond")
 	assert.Equal(t, PID1CONN2RECV3EXPECT, thirdRun[1].BytesReceivedPerSecond, "BytesReceivedPerSecond")
 	assert.Equal(t, PID2CONN1RECV3EXPECT, thirdRun[2].BytesReceivedPerSecond, "BytesReceivedPerSecond")
-
-	// wait for cfg.NetworkRelationCacheDurationMin + a 250 Millisecond buffer to allow the cache expiration to complete
-	time.Sleep(cfg.NetworkRelationCacheDurationMin + 250*time.Millisecond)
 
 	c.cache.Flush()
 }

--- a/checks/net_windows.go
+++ b/checks/net_windows.go
@@ -8,7 +8,6 @@ import (
 	"github.com/StackVista/tcptracer-bpf/pkg/tracer"
 	tracerConfig "github.com/StackVista/tcptracer-bpf/pkg/tracer/config"
 	log "github.com/cihub/seelog"
-	"github.com/patrickmn/go-cache"
 )
 
 // Init initializes a ConnectionsCheck instance.
@@ -43,7 +42,7 @@ func (c *ConnectionsCheck) Init(cfg *config.AgentConfig, sysInfo *model.SystemIn
 		net.GetRemoteNetworkTracerUtil()
 	}
 
-	c.cache = cache.New(cfg.NetworkRelationCacheDurationMin, cfg.NetworkRelationCacheDurationMin)
+	c.cache = NewNetworkRelationCache(cfg.NetworkRelationCacheDurationMin)
 
 	c.buf = new(bytes.Buffer)
 }


### PR DESCRIPTION
Cache was network relation was misused for caching metrics per connection. Introduced inner cache for connections. Also fixed time difference that is used to calculate rate by not using time.Now everytime