### PR TITLE
Stac 20432 Reduce process-agent memory footprint for httpstats map. Make max buffer for http stats configurable.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,7 @@ ENV DOCKER_STS_AGENT=true \
     CURL_CA_BUNDLE=/opt/stackstate-agent/embedded/ssl/certs/cacert.pem
 
 # make sure we have recent dependencies
-RUN apt-get update \
-  # CVE-fixing time!
+RUN apt-get update && apt-get upgrade -y \
   && apt-get install -y util-linux ncurses-bin ncurses-base libncursesw5:amd64 \
   # https://security-tracker.debian.org/tracker/CVE-2018-15686
   && apt-get install -y libudev1 libsystemd0 \

--- a/checks/net.go
+++ b/checks/net.go
@@ -781,18 +781,19 @@ func aggregateHTTPStats(httpStats map[http.Key]*http.RequestStats, duration time
 
 	for connKey, statsByTags := range regroupedStats {
 		for tagsKey, stats := range statsByTags {
+			data := tagsKey.toMap()
 			requestCount, latencies := aggregateStats(stats)
 			result[connKey] = append(result[connKey],
 				makeConnectionMetricWithNumber(
-					httpRequestsDelta, tagsKey.toMap(),
+					httpRequestsDelta, data,
 					float64(requestCount),
 				),
 				makeConnectionMetricWithNumber(
-					httpRequestsPerSecond, tagsKey.toMap(),
+					httpRequestsPerSecond, data,
 					calculateNormalizedRate(uint64(requestCount), duration),
 				),
 				makeConnectionMetricWithHistogram(
-					httpResponseTime, tagsKey.toMap(),
+					httpResponseTime, data,
 					latencies,
 				),
 			)

--- a/config/config.go
+++ b/config/config.go
@@ -42,6 +42,8 @@ type NetworkTracerConfig struct {
 	EnableHTTPTracing bool
 	// Max number of http stats buffered
 	MaxHTTPStatsBuffered int
+	// Max number of http observations buffered
+	MaxHTTPObservationsBuffered int
 }
 
 // APIEndpoint is a single endpoint where process data will be submitted.
@@ -213,11 +215,12 @@ func NewDefaultAgentConfig() *AgentConfig {
 		NetworkTracerInitRetryDuration: 5 * time.Second,
 		NetworkTracerInitRetryAmount:   3,
 		NetworkTracer: &NetworkTracerConfig{
-			EnableProtocolInspection: true,
-			EbpfDebuglogEnabled:      false,
-			EbpfArtifactDir:          "/opt/stackstate-agent/ebpf",
-			EnableHTTPTracing:        false,
-			MaxHTTPStatsBuffered:     100000,
+			EnableProtocolInspection:    true,
+			EbpfDebuglogEnabled:         false,
+			EbpfArtifactDir:             "/opt/stackstate-agent/ebpf",
+			EnableHTTPTracing:           false,
+			MaxHTTPStatsBuffered:        100000,
+			MaxHTTPObservationsBuffered: 100000,
 		},
 
 		// Check config
@@ -478,6 +481,10 @@ func mergeEnvironmentVariables(c *AgentConfig) *AgentConfig {
 
 	if maxStats, err := strconv.Atoi(os.Getenv("STS_HTTP_STATS_BUFFER_SIZE")); err == nil && maxStats != 0 {
 		c.NetworkTracer.MaxHTTPStatsBuffered = maxStats
+	}
+
+	if maxObs, err := strconv.Atoi(os.Getenv("STS_HTTP_OBS_BUFFER_SIZE")); err == nil && maxObs != 0 {
+		c.NetworkTracer.MaxHTTPObservationsBuffered = maxObs
 	}
 
 	var patterns []string

--- a/config/config.go
+++ b/config/config.go
@@ -40,6 +40,8 @@ type NetworkTracerConfig struct {
 	EbpfArtifactDir string
 	// Enabling http tracing using x-reqeust-id headers
 	EnableHTTPTracing bool
+	// Max number of http stats buffered
+	MaxHTTPStatsBuffered int
 }
 
 // APIEndpoint is a single endpoint where process data will be submitted.
@@ -215,6 +217,7 @@ func NewDefaultAgentConfig() *AgentConfig {
 			EbpfDebuglogEnabled:      false,
 			EbpfArtifactDir:          "/opt/stackstate-agent/ebpf",
 			EnableHTTPTracing:        false,
+			MaxHTTPStatsBuffered:     100000,
 		},
 
 		// Check config
@@ -471,6 +474,10 @@ func mergeEnvironmentVariables(c *AgentConfig) *AgentConfig {
 
 	if ok, err := isAffirmative(os.Getenv("STS_HTTP_TRACING_ENABLED")); err == nil {
 		c.NetworkTracer.EnableHTTPTracing = ok
+	}
+
+	if maxStats, err := strconv.Atoi(os.Getenv("STS_HTTP_STATS_BUFFER_SIZE")); err == nil && maxStats != 0 {
+		c.NetworkTracer.MaxHTTPStatsBuffered = maxStats
 	}
 
 	var patterns []string

--- a/config/config.go
+++ b/config/config.go
@@ -483,7 +483,7 @@ func mergeEnvironmentVariables(c *AgentConfig) *AgentConfig {
 		c.NetworkTracer.MaxHTTPStatsBuffered = maxStats
 	}
 
-	if maxObs, err := strconv.Atoi(os.Getenv("STS_HTTP_OBS_BUFFER_SIZE")); err == nil && maxObs != 0 {
+	if maxObs, err := strconv.Atoi(os.Getenv("STS_HTTP_OBSERVATIONS_BUFFER_SIZE")); err == nil && maxObs != 0 {
 		c.NetworkTracer.MaxHTTPObservationsBuffered = maxObs
 	}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -599,6 +599,38 @@ network_tracer_config:
 	assert.Equal(true, agentConfig.NetworkTracer.EnableHTTPTracing)
 }
 
+func TestStackStateMaxHttpStatsBufferPresent(t *testing.T) {
+	assert := assert.New(t)
+	var ddy YamlAgentConfig
+	err := yaml.Unmarshal(
+		[]byte(`
+network_tracer_config:
+  http_stats_buffer_size: '200000'
+`), &ddy)
+	assert.NoError(err)
+
+	agentConfig, err := NewAgentConfig(&ddy)
+	assert.NoError(err)
+
+	assert.Equal(200000, agentConfig.NetworkTracer.MaxHTTPStatsBuffered)
+}
+
+func TestStackStateMaxHttpStatsBufferAbsent(t *testing.T) {
+	assert := assert.New(t)
+	var ddy YamlAgentConfig
+	err := yaml.Unmarshal(
+		[]byte(`
+network_tracer_config:
+  protocol_inspection_enabled: 'false'
+`), &ddy)
+	assert.NoError(err)
+
+	agentConfig, err := NewAgentConfig(&ddy)
+	assert.NoError(err)
+
+	assert.Equal(100000, agentConfig.NetworkTracer.MaxHTTPStatsBuffered)
+}
+
 func TestEnvOverrides(t *testing.T) {
 	assert := assert.New(t)
 	os.Setenv("STS_NETWORK_TRACER_MAX_CONNECTIONS", "500")
@@ -609,6 +641,7 @@ func TestEnvOverrides(t *testing.T) {
 	os.Setenv("STS_NETWORK_TRACING_ENABLED", "true")
 	os.Setenv("STS_HTTP_TRACING_ENABLED", "true")
 	os.Setenv("STS_EBPF_DEBUG_LOG_ENABLED", "true")
+	os.Setenv("STS_HTTP_STATS_BUFFER_SIZE", "150000")
 
 	agentConfig, _ := NewAgentConfig(nil)
 
@@ -619,6 +652,7 @@ func TestEnvOverrides(t *testing.T) {
 	assert.Equal(true, agentConfig.EnableNetworkTracing)
 	assert.Equal(true, agentConfig.NetworkTracer.EbpfDebuglogEnabled)
 	assert.Equal(true, agentConfig.NetworkTracer.EnableHTTPTracing)
+	assert.Equal(150000, agentConfig.NetworkTracer.MaxHTTPStatsBuffered)
 }
 
 func TestEnvSiteConfig(t *testing.T) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -631,6 +631,38 @@ network_tracer_config:
 	assert.Equal(100000, agentConfig.NetworkTracer.MaxHTTPStatsBuffered)
 }
 
+func TestStackStateMaxHttpObservationsBufferPresent(t *testing.T) {
+	assert := assert.New(t)
+	var ddy YamlAgentConfig
+	err := yaml.Unmarshal(
+		[]byte(`
+network_tracer_config:
+  http_observations_buffer_size: 200000
+`), &ddy)
+	assert.NoError(err)
+
+	agentConfig, err := NewAgentConfig(&ddy)
+	assert.NoError(err)
+
+	assert.Equal(200000, agentConfig.NetworkTracer.MaxHTTPObservationsBuffered)
+}
+
+func TestStackStateMaxHttpObservationsBufferAbsent(t *testing.T) {
+	assert := assert.New(t)
+	var ddy YamlAgentConfig
+	err := yaml.Unmarshal(
+		[]byte(`
+network_tracer_config:
+  protocol_inspection_enabled: 'false'
+`), &ddy)
+	assert.NoError(err)
+
+	agentConfig, err := NewAgentConfig(&ddy)
+	assert.NoError(err)
+
+	assert.Equal(100000, agentConfig.NetworkTracer.MaxHTTPObservationsBuffered)
+}
+
 func TestEnvOverrides(t *testing.T) {
 	assert := assert.New(t)
 	os.Setenv("STS_NETWORK_TRACER_MAX_CONNECTIONS", "500")
@@ -642,6 +674,7 @@ func TestEnvOverrides(t *testing.T) {
 	os.Setenv("STS_HTTP_TRACING_ENABLED", "true")
 	os.Setenv("STS_EBPF_DEBUG_LOG_ENABLED", "true")
 	os.Setenv("STS_HTTP_STATS_BUFFER_SIZE", "150000")
+	os.Setenv("STS_HTTP_OBS_BUFFER_SIZE", "160000")
 
 	agentConfig, _ := NewAgentConfig(nil)
 
@@ -653,6 +686,7 @@ func TestEnvOverrides(t *testing.T) {
 	assert.Equal(true, agentConfig.NetworkTracer.EbpfDebuglogEnabled)
 	assert.Equal(true, agentConfig.NetworkTracer.EnableHTTPTracing)
 	assert.Equal(150000, agentConfig.NetworkTracer.MaxHTTPStatsBuffered)
+	assert.Equal(160000, agentConfig.NetworkTracer.MaxHTTPObservationsBuffered)
 }
 
 func TestEnvSiteConfig(t *testing.T) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -605,7 +605,7 @@ func TestStackStateMaxHttpStatsBufferPresent(t *testing.T) {
 	err := yaml.Unmarshal(
 		[]byte(`
 network_tracer_config:
-  http_stats_buffer_size: '200000'
+  http_stats_buffer_size: 200000
 `), &ddy)
 	assert.NoError(err)
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -674,7 +674,7 @@ func TestEnvOverrides(t *testing.T) {
 	os.Setenv("STS_HTTP_TRACING_ENABLED", "true")
 	os.Setenv("STS_EBPF_DEBUG_LOG_ENABLED", "true")
 	os.Setenv("STS_HTTP_STATS_BUFFER_SIZE", "150000")
-	os.Setenv("STS_HTTP_OBS_BUFFER_SIZE", "160000")
+	os.Setenv("STS_HTTP_OBSERVATIONS_BUFFER_SIZE", "160000")
 
 	agentConfig, _ := NewAgentConfig(nil)
 

--- a/config/tracer_config.go
+++ b/config/tracer_config.go
@@ -55,8 +55,8 @@ func TracerConfig(cfg *AgentConfig) *tracerConfig.Config {
 		EnableHTTPMonitoring:        cfg.NetworkTracer.EnableProtocolInspection,
 		EnableHTTPSMonitoring:       cfg.NetworkTracer.EnableProtocolInspection,
 		EnableHTTPTracing:           cfg.NetworkTracer.EnableHTTPTracing,
-		MaxHTTPStatsBuffered:        100000,
-		MaxHTTPObservationsBuffered: 100000, // This is the default from datadog
+		MaxHTTPStatsBuffered:        cfg.NetworkTracer.MaxHTTPStatsBuffered, // 100000,
+		MaxHTTPObservationsBuffered: 100000,                                 // This is the default from datadog
 
 		MaxTrackedHTTPConnections: 1024,
 		HTTPNotificationThreshold: 512,

--- a/config/tracer_config.go
+++ b/config/tracer_config.go
@@ -55,8 +55,8 @@ func TracerConfig(cfg *AgentConfig) *tracerConfig.Config {
 		EnableHTTPMonitoring:        cfg.NetworkTracer.EnableProtocolInspection,
 		EnableHTTPSMonitoring:       cfg.NetworkTracer.EnableProtocolInspection,
 		EnableHTTPTracing:           cfg.NetworkTracer.EnableHTTPTracing,
-		MaxHTTPStatsBuffered:        cfg.NetworkTracer.MaxHTTPStatsBuffered, // 100000,
-		MaxHTTPObservationsBuffered: 100000,                                 // This is the default from datadog
+		MaxHTTPStatsBuffered:        cfg.NetworkTracer.MaxHTTPStatsBuffered,        // 100000,
+		MaxHTTPObservationsBuffered: cfg.NetworkTracer.MaxHTTPObservationsBuffered, // 100000 is the default from datadog
 
 		MaxTrackedHTTPConnections: 1024,
 		HTTPNotificationThreshold: 512,

--- a/config/yaml_config.go
+++ b/config/yaml_config.go
@@ -136,9 +136,10 @@ type YamlAgentConfig struct {
 		// A string indicating the enabled state of the protocol inspection.
 		ProtocolInspectionEnabled string `yaml:"protocol_inspection_enabled"`
 		// A string indicating the enabled state of the protocol inspection.
-		HTTPTracingEnabled   string `yaml:"http_tracing_enabled"`
-		MaxHTTPStatsBuffered int    `yaml:"http_stats_buffer_size"`
-		HTTPMetrics          struct {
+		HTTPTracingEnabled          string `yaml:"http_tracing_enabled"`
+		MaxHTTPStatsBuffered        int    `yaml:"http_stats_buffer_size"`
+		MaxHTTPObservationsBuffered int    `yaml:"http_observations_buffer_size"`
+		HTTPMetrics                 struct {
 			// Specifies which algorithm to use to collapse measurements: collapsing_lowest_dense, collapsing_highest_dense, unbounded
 			SketchType string `yaml:"sketch_type"`
 			// A maximum number of bins of the ddSketch we use to store percentiles
@@ -413,6 +414,9 @@ func mergeNetworkYamlConfig(agentConf *AgentConfig, networkConf *YamlAgentConfig
 	}
 	if networkConf.Network.MaxHTTPStatsBuffered != 0 {
 		agentConf.NetworkTracer.MaxHTTPStatsBuffered = networkConf.Network.MaxHTTPStatsBuffered
+	}
+	if networkConf.Network.MaxHTTPObservationsBuffered != 0 {
+		agentConf.NetworkTracer.MaxHTTPObservationsBuffered = networkConf.Network.MaxHTTPObservationsBuffered
 	}
 	if networkConf.Network.NetworkMaxConnections != 0 {
 		agentConf.NetworkTracerMaxConnections = networkConf.Network.NetworkMaxConnections

--- a/config/yaml_config.go
+++ b/config/yaml_config.go
@@ -136,8 +136,9 @@ type YamlAgentConfig struct {
 		// A string indicating the enabled state of the protocol inspection.
 		ProtocolInspectionEnabled string `yaml:"protocol_inspection_enabled"`
 		// A string indicating the enabled state of the protocol inspection.
-		HTTPTracingEnabled string `yaml:"http_tracing_enabled"`
-		HTTPMetrics        struct {
+		HTTPTracingEnabled   string `yaml:"http_tracing_enabled"`
+		MaxHTTPStatsBuffered int    `yaml:"http_stats_buffer_size"`
+		HTTPMetrics          struct {
 			// Specifies which algorithm to use to collapse measurements: collapsing_lowest_dense, collapsing_highest_dense, unbounded
 			SketchType string `yaml:"sketch_type"`
 			// A maximum number of bins of the ddSketch we use to store percentiles
@@ -409,6 +410,9 @@ func mergeNetworkYamlConfig(agentConf *AgentConfig, networkConf *YamlAgentConfig
 	}
 	if httpTracingEnabled, err := isAffirmative(networkConf.Network.HTTPTracingEnabled); err == nil {
 		agentConf.NetworkTracer.EnableHTTPTracing = httpTracingEnabled
+	}
+	if networkConf.Network.MaxHTTPStatsBuffered != 0 {
+		agentConf.NetworkTracer.MaxHTTPStatsBuffered = networkConf.Network.MaxHTTPStatsBuffered
 	}
 	if networkConf.Network.NetworkMaxConnections != 0 {
 		agentConf.NetworkTracerMaxConnections = networkConf.Network.NetworkMaxConnections

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/StackVista/stackstate-process-agent
 
-go 1.18
+go 1.19
 
 // From datadog-agent-upstream-for-process-agent, replaces done in that go mod file need to be done here too
 replace github.com/pahanini/go-grpc-bidirectional-streaming-example v0.0.0-20211027164128-cc6111af44be => github.com/DataDog/go-grpc-bidirectional-streaming-example v0.0.0-20221024060302-b9cf785c02fe


### PR DESCRIPTION
### Step 1: Link to Jira issue


### Step 2: Description of changes


### Step 3: Did you add / update tests for your changes in the right area?
- [ ] Unit/Component test		


### Step 4: I'm confident that everything is properly tested:
I got a PO / QA Approval by:
- [ ] Name

### Step 5: Can we ship this feature to production?
- [ ] Yes, I'm proud of my work. Ship it! :ship: