### PR TITLE
STAC-20811: Add support for HTTP/2 stats and per-path HTTP metrics

### DIFF
--- a/.venv
+++ b/.venv
@@ -1,1 +1,1 @@
-stackstate-process-agent-dkqt
+stackstate-process-agent-gdsy

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1048,3 +1048,14 @@ func TestSkipKubeletTLSVerify_FromEnv(t *testing.T) {
 
 	os.Unsetenv("STS_SKIP_KUBELET_TLS_VERIFY")
 }
+
+func TestHTTPStatsPerPath_FromEnv(t *testing.T) {
+	os.Setenv("STS_HTTP_STATS_PER_PATH", "true")
+
+	conf, err := NewAgentConfig(nil)
+	assert.NoError(t, err)
+
+	assert.Equal(t, true, conf.HTTPStatsPerPath)
+
+	os.Unsetenv("STS_HTTP_STATS_PER_PATH")
+}

--- a/config/tracer_config.go
+++ b/config/tracer_config.go
@@ -63,7 +63,7 @@ func TracerConfig(cfg *AgentConfig) *tracerConfig.Config {
 		EnableAMQPMonitoring: cfg.NetworkTracer.EnableProtocolInspection,
 		MaxAMQPStatsBuffered: 100000,
 
-		EnableNativeTLSMonitoring: cfg.NetworkTracer.EnableHTTPSInspection,
+		EnableNativeTLSMonitoring: cfg.NetworkTracer.EnableProtocolInspection,
 		EnableIstioMonitoring:     false,
 		EnableGoTLSSupport:        false,
 		EnableJavaTLSSupport:      false,

--- a/go.mod
+++ b/go.mod
@@ -500,4 +500,4 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 )
 
-replace github.com/DataDog/datadog-agent => github.com/StackVista/datadog-agent-upstream-for-process-agent v0.0.0-20240212115601-e86387ce74e3
+replace github.com/DataDog/datadog-agent => github.com/StackVista/datadog-agent-upstream-for-process-agent v0.0.0-20240212124220-c2d8b0797860

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/StackVista/stackstate-process-agent
 
 go 1.20
 
-replace github.com/DataDog/datadog-agent => github.com/StackVista/datadog-agent-upstream-for-process-agent v0.0.0-20240208122803-f3c1cc27b624
-
 // From datadog-agent-upstream-for-process-agent, replaces done in that go mod file need to be done here too
 replace github.com/pahanini/go-grpc-bidirectional-streaming-example v0.0.0-20211027164128-cc6111af44be => github.com/DataDog/go-grpc-bidirectional-streaming-example v0.0.0-20221024060302-b9cf785c02fe
 
@@ -501,3 +499,5 @@ require (
 	sigs.k8s.io/kustomize/kyaml v0.13.9 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 )
+
+replace github.com/DataDog/datadog-agent => github.com/StackVista/datadog-agent-upstream-for-process-agent v0.0.0-20240212115601-e86387ce74e3

--- a/go.sum
+++ b/go.sum
@@ -191,8 +191,8 @@ github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d h1:UrqY+r/O
 github.com/StackExchange/wmi v0.0.0-20181212234831-e0a55b97c705/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/StackExchange/wmi v1.2.1 h1:VIkavFPXSjcnS+O8yTq7NI32k0R5Aj+v39y29VYDOSA=
 github.com/StackExchange/wmi v1.2.1/go.mod h1:rcmrprowKIVzvc+NUiLncP2uuArMWLCbu9SBzvHz7e8=
-github.com/StackVista/datadog-agent-upstream-for-process-agent v0.0.0-20240212115601-e86387ce74e3 h1:NbaqCI6EUZaCFy7bSP7P3wib2oFEZrvOc/4EJAKlH5A=
-github.com/StackVista/datadog-agent-upstream-for-process-agent v0.0.0-20240212115601-e86387ce74e3/go.mod h1:b87zqQerXQiLND+Ma6sRteu/wX0Uk6DAkKtSFJegF4c=
+github.com/StackVista/datadog-agent-upstream-for-process-agent v0.0.0-20240212124220-c2d8b0797860 h1:6QspkjJuSHAVH4vYXsXTt8XllYH03juPOxeZ+sTKjTc=
+github.com/StackVista/datadog-agent-upstream-for-process-agent v0.0.0-20240212124220-c2d8b0797860/go.mod h1:b87zqQerXQiLND+Ma6sRteu/wX0Uk6DAkKtSFJegF4c=
 github.com/StackVista/netlink v0.0.0-20231207101142-91d41874606b h1:9UZEx5+IBk26JfiMnUrNwE7J5bcC5zYtWwI4O8Q540I=
 github.com/StackVista/netlink v0.0.0-20231207101142-91d41874606b/go.mod h1:twkDnbuQxJYemMlGd4JFIcuhgX83tXhKS2B/PRMpOho=
 github.com/StackVista/sketches-go v1.2.0-pre h1:04QAbYurRVq5LY6VK0KbFPUi4YhJcpEi5AansGdLdMw=

--- a/go.sum
+++ b/go.sum
@@ -191,8 +191,8 @@ github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d h1:UrqY+r/O
 github.com/StackExchange/wmi v0.0.0-20181212234831-e0a55b97c705/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/StackExchange/wmi v1.2.1 h1:VIkavFPXSjcnS+O8yTq7NI32k0R5Aj+v39y29VYDOSA=
 github.com/StackExchange/wmi v1.2.1/go.mod h1:rcmrprowKIVzvc+NUiLncP2uuArMWLCbu9SBzvHz7e8=
-github.com/StackVista/datadog-agent-upstream-for-process-agent v0.0.0-20240208122803-f3c1cc27b624 h1:SPQDLhXHhTL/1AtWp40jvwRQLIxpgHD9PKVIfEiX/RU=
-github.com/StackVista/datadog-agent-upstream-for-process-agent v0.0.0-20240208122803-f3c1cc27b624/go.mod h1:b87zqQerXQiLND+Ma6sRteu/wX0Uk6DAkKtSFJegF4c=
+github.com/StackVista/datadog-agent-upstream-for-process-agent v0.0.0-20240212115601-e86387ce74e3 h1:NbaqCI6EUZaCFy7bSP7P3wib2oFEZrvOc/4EJAKlH5A=
+github.com/StackVista/datadog-agent-upstream-for-process-agent v0.0.0-20240212115601-e86387ce74e3/go.mod h1:b87zqQerXQiLND+Ma6sRteu/wX0Uk6DAkKtSFJegF4c=
 github.com/StackVista/netlink v0.0.0-20231207101142-91d41874606b h1:9UZEx5+IBk26JfiMnUrNwE7J5bcC5zYtWwI4O8Q540I=
 github.com/StackVista/netlink v0.0.0-20231207101142-91d41874606b/go.mod h1:twkDnbuQxJYemMlGd4JFIcuhgX83tXhKS2B/PRMpOho=
 github.com/StackVista/sketches-go v1.2.0-pre h1:04QAbYurRVq5LY6VK0KbFPUi4YhJcpEi5AansGdLdMw=


### PR DESCRIPTION
- Collects HTTP 2 metrics along with HTTP 1  ones, simply forwarding all of them as `http` for now.
- Adds a `HTTPStatsPerPath` setting (via `STS_HTTP_STATS_PER_PATH` environment variable) to show per-path HTTP metrics. We need this for the demo because it gives us information about the gRPC endpoint being called in the gRPC-over-HTTP2 case.

The agent does not capture TLS-encrypted HTTP2 payloads yet, so this works only for unencrypted HTTP2, which is rarely seen outside of demo setups. For the progress of the TLS-enabled HTTP2 work done by DataDog, see https://github.com/DataDog/datadog-agent/pull/22460, https://github.com/DataDog/datadog-agent/pull/22226, https://github.com/DataDog/datadog-agent/pull/21913, https://github.com/DataDog/datadog-agent/pull/21808, and https://github.com/DataDog/datadog-agent/pull/21619. We will need to merge these into our branch to gain that functionality.

- [x] Wait for https://gitlab.com/stackvista/agent/datadog-agent-upstream-for-process-agent/-/merge_requests/17, then update dependency.
