### PR TITLE
STAC-20951: eBPF verifier issues

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -49,6 +49,8 @@ type NetworkTracerConfig struct {
 	MaxHTTPStatsBuffered int
 	// Max number of http observations buffered
 	MaxHTTPObservationsBuffered int
+	// Protocols to disable, mostly for debugging
+	DisabledProtocols []string
 }
 
 // APIEndpoint is a single endpoint where process data will be submitted.
@@ -232,6 +234,7 @@ func NewDefaultAgentConfig() *AgentConfig {
 			ProbeLogBufferSizeBytes:     16000000,
 			MaxHTTPStatsBuffered:        100000,
 			MaxHTTPObservationsBuffered: 100000,
+			DisabledProtocols:           []string{},
 		},
 
 		// Check config
@@ -516,6 +519,14 @@ func mergeEnvironmentVariables(c *AgentConfig) *AgentConfig {
 
 	if maxObs, err := strconv.Atoi(os.Getenv("STS_HTTP_OBSERVATIONS_BUFFER_SIZE")); err == nil && maxObs != 0 {
 		c.NetworkTracer.MaxHTTPObservationsBuffered = maxObs
+	}
+
+	if v := os.Getenv("STS_DISABLED_PROTOCOLS"); v != "" {
+		protocols := strings.Split(v, ",")
+		for i, proto := range protocols {
+			protocols[i] = strings.ToLower(proto)
+		}
+		c.NetworkTracer.DisabledProtocols = protocols
 	}
 
 	var patterns []string

--- a/config/tracer_config.go
+++ b/config/tracer_config.go
@@ -7,6 +7,7 @@ import (
 	tracerConfig "github.com/DataDog/datadog-agent/pkg/network/config"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	log "github.com/cihub/seelog"
+	"k8s.io/utils/strings/slices"
 )
 
 // TracerConfig creates a config for the network tracer
@@ -52,18 +53,18 @@ func TracerConfig(cfg *AgentConfig) *tracerConfig.Config {
 
 		ProtocolClassificationEnabled: cfg.NetworkTracer.EnableProtocolInspection,
 
-		EnableHTTPMonitoring:  cfg.NetworkTracer.EnableProtocolInspection,
-		EnableHTTP2Monitoring: cfg.NetworkTracer.EnableProtocolInspection,
+		EnableHTTPMonitoring:  cfg.NetworkTracer.EnableProtocolInspection && slices.Contains(cfg.NetworkTracer.DisabledProtocols, "http"),
+		EnableHTTP2Monitoring: cfg.NetworkTracer.EnableProtocolInspection && slices.Contains(cfg.NetworkTracer.DisabledProtocols, "http2"),
 
-		EnableKafkaMonitoring: false,
+		EnableKafkaMonitoring: false && slices.Contains(cfg.NetworkTracer.DisabledProtocols, "kafka"),
 
-		EnableMongoMonitoring: cfg.NetworkTracer.EnableProtocolInspection,
+		EnableMongoMonitoring: cfg.NetworkTracer.EnableProtocolInspection && slices.Contains(cfg.NetworkTracer.DisabledProtocols, "mongo"),
 		MaxMongoStatsBuffered: 100000,
 
-		EnableAMQPMonitoring: cfg.NetworkTracer.EnableProtocolInspection,
+		EnableAMQPMonitoring: cfg.NetworkTracer.EnableProtocolInspection && slices.Contains(cfg.NetworkTracer.DisabledProtocols, "amqp"),
 		MaxAMQPStatsBuffered: 100000,
 
-		EnableNativeTLSMonitoring: cfg.NetworkTracer.EnableProtocolInspection,
+		EnableNativeTLSMonitoring: cfg.NetworkTracer.EnableProtocolInspection && slices.Contains(cfg.NetworkTracer.DisabledProtocols, "tls"),
 		EnableIstioMonitoring:     false,
 		EnableGoTLSSupport:        false,
 		EnableJavaTLSSupport:      false,

--- a/config/tracer_config.go
+++ b/config/tracer_config.go
@@ -53,18 +53,18 @@ func TracerConfig(cfg *AgentConfig) *tracerConfig.Config {
 
 		ProtocolClassificationEnabled: cfg.NetworkTracer.EnableProtocolInspection,
 
-		EnableHTTPMonitoring:  cfg.NetworkTracer.EnableProtocolInspection && slices.Contains(cfg.NetworkTracer.DisabledProtocols, "http"),
-		EnableHTTP2Monitoring: cfg.NetworkTracer.EnableProtocolInspection && slices.Contains(cfg.NetworkTracer.DisabledProtocols, "http2"),
+		EnableHTTPMonitoring:  cfg.NetworkTracer.EnableProtocolInspection && !slices.Contains(cfg.NetworkTracer.DisabledProtocols, "http"),
+		EnableHTTP2Monitoring: cfg.NetworkTracer.EnableProtocolInspection && !slices.Contains(cfg.NetworkTracer.DisabledProtocols, "http2"),
 
-		EnableKafkaMonitoring: false && slices.Contains(cfg.NetworkTracer.DisabledProtocols, "kafka"),
+		EnableKafkaMonitoring: false && !slices.Contains(cfg.NetworkTracer.DisabledProtocols, "kafka"),
 
-		EnableMongoMonitoring: cfg.NetworkTracer.EnableProtocolInspection && slices.Contains(cfg.NetworkTracer.DisabledProtocols, "mongo"),
+		EnableMongoMonitoring: cfg.NetworkTracer.EnableProtocolInspection && !slices.Contains(cfg.NetworkTracer.DisabledProtocols, "mongo"),
 		MaxMongoStatsBuffered: 100000,
 
-		EnableAMQPMonitoring: cfg.NetworkTracer.EnableProtocolInspection && slices.Contains(cfg.NetworkTracer.DisabledProtocols, "amqp"),
+		EnableAMQPMonitoring: cfg.NetworkTracer.EnableProtocolInspection && !slices.Contains(cfg.NetworkTracer.DisabledProtocols, "amqp"),
 		MaxAMQPStatsBuffered: 100000,
 
-		EnableNativeTLSMonitoring: cfg.NetworkTracer.EnableProtocolInspection && slices.Contains(cfg.NetworkTracer.DisabledProtocols, "tls"),
+		EnableNativeTLSMonitoring: cfg.NetworkTracer.EnableProtocolInspection && !slices.Contains(cfg.NetworkTracer.DisabledProtocols, "tls"),
 		EnableIstioMonitoring:     false,
 		EnableGoTLSSupport:        false,
 		EnableJavaTLSSupport:      false,

--- a/config/yaml_config.go
+++ b/config/yaml_config.go
@@ -2,10 +2,11 @@ package config
 
 import (
 	"fmt"
-	"github.com/DataDog/datadog-agent/pkg/util/filesystem"
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/util/filesystem"
 
 	log "github.com/cihub/seelog"
 	"gopkg.in/yaml.v2"
@@ -139,9 +140,11 @@ type YamlAgentConfig struct {
 		// ProbeDebugLog logging when loading probe
 		ProbeDebugLog string `yaml:"probe_debug_log_enabled"`
 		// ProbeLogBufferSizeBytes increase the probe log buffer for debugging purposes
-		ProbeLogBufferSizeBytes     int `yaml:"probe_log_buffer_size_bytes"`
-		MaxHTTPStatsBuffered        int `yaml:"http_stats_buffer_size"`
-		MaxHTTPObservationsBuffered int `yaml:"http_observations_buffer_size"`
+		ProbeLogBufferSizeBytes int `yaml:"probe_log_buffer_size_bytes"`
+		// Protocol probes to be disabled, mostly for debugging.
+		DisabledProtocols           []string `yaml:"disabled_protocols"`
+		MaxHTTPStatsBuffered        int      `yaml:"http_stats_buffer_size"`
+		MaxHTTPObservationsBuffered int      `yaml:"http_observations_buffer_size"`
 		HTTPMetrics                 struct {
 			// Specifies which algorithm to use to collapse measurements: collapsing_lowest_dense, collapsing_highest_dense, unbounded
 			SketchType string `yaml:"sketch_type"`
@@ -432,6 +435,9 @@ func mergeNetworkYamlConfig(agentConf *AgentConfig, networkConf *YamlAgentConfig
 	}
 	if networkConf.Network.EBPFArtifactDir != "" {
 		agentConf.NetworkTracer.EbpfArtifactDir = networkConf.Network.EBPFArtifactDir
+	}
+	if networkConf.Network.DisabledProtocols != nil {
+		agentConf.NetworkTracer.DisabledProtocols = networkConf.Network.DisabledProtocols
 	}
 	return agentConf, nil
 }


### PR DESCRIPTION
This adds the option to disable certain protocol parses for debugging purposes. It can be done by passing a comma-separated list of protocols in environment variable `STS_DISABLED_PROTOCOLS` or by using the new `disabled_protocols` option in the YAML config, under `network_tracer_config`.