### PR TITLE
STAC-21361: Use new upstream version

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -9,3 +9,29 @@ rake build
 
 docker build . --tag europe-west4-docker.pkg.dev/stackstate-sandbox-390311/dev/stackstate-process-agent:dev
 docker push europe-west4-docker.pkg.dev/stackstate-sandbox-390311/dev/stackstate-process-agent:dev
+
+cat << EOF
+Run it like so:
+
+docker run \\
+    --rm \\
+    -it \\
+    --privileged \\
+    -e STS_API_KEY=none \\
+    -e STS_PROCESS_AGENT_URL=none \\
+    -e STS_CLUSTER_AGENT_ENABLED=true \\
+    -e STS_LOG_TO_CONSOLE=true \\
+    -v /sys/kernel/debug:/sys/kernel/debug \\
+    -e HOST_ETC=/host/etc \\
+    -e HOST_SYS=/host/sys \\
+    -e HOST_PROC=/host/proc \\
+    -v /sys:/host/sys \\
+    -v /proc:/host/proc \\
+    -v /etc:/host/etc \\
+    -e STS_NETWORK_TRACING_ENABLED=true \\
+    -e STS_PROTOCOL_INSPECTION_ENABLED=true \\
+    -e STS_PROCESS_AGENT_ENABLED=true \\
+    europe-west4-docker.pkg.dev/stackstate-sandbox-390311/dev/stackstate-process-agent:dev
+
+EOF
+

--- a/go.mod
+++ b/go.mod
@@ -500,4 +500,4 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 )
 
-replace github.com/DataDog/datadog-agent => github.com/StackVista/datadog-agent-upstream-for-process-agent v0.0.0-20240618142204-94efd72cde98
+replace github.com/DataDog/datadog-agent => github.com/StackVista/datadog-agent-upstream-for-process-agent v0.0.0-20240617080032-c7e8e449f9e1

--- a/go.mod
+++ b/go.mod
@@ -500,4 +500,4 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 )
 
-replace github.com/DataDog/datadog-agent => github.com/StackVista/datadog-agent-upstream-for-process-agent v0.0.0-20240305080252-edda5c0f4b09
+replace github.com/DataDog/datadog-agent => github.com/StackVista/datadog-agent-upstream-for-process-agent v0.0.0-20240617080032-c7e8e449f9e1

--- a/go.mod
+++ b/go.mod
@@ -500,4 +500,4 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 )
 
-replace github.com/DataDog/datadog-agent => github.com/StackVista/datadog-agent-upstream-for-process-agent v0.0.0-20240617080032-c7e8e449f9e1
+replace github.com/DataDog/datadog-agent => github.com/StackVista/datadog-agent-upstream-for-process-agent v0.0.0-20240618142204-94efd72cde98

--- a/go.mod
+++ b/go.mod
@@ -500,4 +500,4 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 )
 
-replace github.com/DataDog/datadog-agent => github.com/StackVista/datadog-agent-upstream-for-process-agent v0.0.0-20240617080032-c7e8e449f9e1
+replace github.com/DataDog/datadog-agent => github.com/StackVista/datadog-agent-upstream-for-process-agent v0.0.0-20240618145435-157bd324d70b

--- a/go.sum
+++ b/go.sum
@@ -191,8 +191,8 @@ github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d h1:UrqY+r/O
 github.com/StackExchange/wmi v0.0.0-20181212234831-e0a55b97c705/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/StackExchange/wmi v1.2.1 h1:VIkavFPXSjcnS+O8yTq7NI32k0R5Aj+v39y29VYDOSA=
 github.com/StackExchange/wmi v1.2.1/go.mod h1:rcmrprowKIVzvc+NUiLncP2uuArMWLCbu9SBzvHz7e8=
-github.com/StackVista/datadog-agent-upstream-for-process-agent v0.0.0-20240618142204-94efd72cde98 h1:AuE7SAQ+NpCA7dsIFkJDxnfF/odXnL8r+LbJi3ZSOzU=
-github.com/StackVista/datadog-agent-upstream-for-process-agent v0.0.0-20240618142204-94efd72cde98/go.mod h1:b87zqQerXQiLND+Ma6sRteu/wX0Uk6DAkKtSFJegF4c=
+github.com/StackVista/datadog-agent-upstream-for-process-agent v0.0.0-20240617080032-c7e8e449f9e1 h1:nfna/saQ8g9/eQtdkcdH2riQZerEfiM6OX5tvhTCNVw=
+github.com/StackVista/datadog-agent-upstream-for-process-agent v0.0.0-20240617080032-c7e8e449f9e1/go.mod h1:b87zqQerXQiLND+Ma6sRteu/wX0Uk6DAkKtSFJegF4c=
 github.com/StackVista/netlink v0.0.0-20231207101142-91d41874606b h1:9UZEx5+IBk26JfiMnUrNwE7J5bcC5zYtWwI4O8Q540I=
 github.com/StackVista/netlink v0.0.0-20231207101142-91d41874606b/go.mod h1:twkDnbuQxJYemMlGd4JFIcuhgX83tXhKS2B/PRMpOho=
 github.com/StackVista/sketches-go v1.2.0-pre h1:04QAbYurRVq5LY6VK0KbFPUi4YhJcpEi5AansGdLdMw=

--- a/go.sum
+++ b/go.sum
@@ -191,8 +191,8 @@ github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d h1:UrqY+r/O
 github.com/StackExchange/wmi v0.0.0-20181212234831-e0a55b97c705/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/StackExchange/wmi v1.2.1 h1:VIkavFPXSjcnS+O8yTq7NI32k0R5Aj+v39y29VYDOSA=
 github.com/StackExchange/wmi v1.2.1/go.mod h1:rcmrprowKIVzvc+NUiLncP2uuArMWLCbu9SBzvHz7e8=
-github.com/StackVista/datadog-agent-upstream-for-process-agent v0.0.0-20240305080252-edda5c0f4b09 h1:MYqXVlqGcDnbKtPIat4wapy0qxLrieA1VuiOD7akgeg=
-github.com/StackVista/datadog-agent-upstream-for-process-agent v0.0.0-20240305080252-edda5c0f4b09/go.mod h1:b87zqQerXQiLND+Ma6sRteu/wX0Uk6DAkKtSFJegF4c=
+github.com/StackVista/datadog-agent-upstream-for-process-agent v0.0.0-20240617080032-c7e8e449f9e1 h1:nfna/saQ8g9/eQtdkcdH2riQZerEfiM6OX5tvhTCNVw=
+github.com/StackVista/datadog-agent-upstream-for-process-agent v0.0.0-20240617080032-c7e8e449f9e1/go.mod h1:b87zqQerXQiLND+Ma6sRteu/wX0Uk6DAkKtSFJegF4c=
 github.com/StackVista/netlink v0.0.0-20231207101142-91d41874606b h1:9UZEx5+IBk26JfiMnUrNwE7J5bcC5zYtWwI4O8Q540I=
 github.com/StackVista/netlink v0.0.0-20231207101142-91d41874606b/go.mod h1:twkDnbuQxJYemMlGd4JFIcuhgX83tXhKS2B/PRMpOho=
 github.com/StackVista/sketches-go v1.2.0-pre h1:04QAbYurRVq5LY6VK0KbFPUi4YhJcpEi5AansGdLdMw=

--- a/go.sum
+++ b/go.sum
@@ -191,8 +191,8 @@ github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d h1:UrqY+r/O
 github.com/StackExchange/wmi v0.0.0-20181212234831-e0a55b97c705/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/StackExchange/wmi v1.2.1 h1:VIkavFPXSjcnS+O8yTq7NI32k0R5Aj+v39y29VYDOSA=
 github.com/StackExchange/wmi v1.2.1/go.mod h1:rcmrprowKIVzvc+NUiLncP2uuArMWLCbu9SBzvHz7e8=
-github.com/StackVista/datadog-agent-upstream-for-process-agent v0.0.0-20240617080032-c7e8e449f9e1 h1:nfna/saQ8g9/eQtdkcdH2riQZerEfiM6OX5tvhTCNVw=
-github.com/StackVista/datadog-agent-upstream-for-process-agent v0.0.0-20240617080032-c7e8e449f9e1/go.mod h1:b87zqQerXQiLND+Ma6sRteu/wX0Uk6DAkKtSFJegF4c=
+github.com/StackVista/datadog-agent-upstream-for-process-agent v0.0.0-20240618142204-94efd72cde98 h1:AuE7SAQ+NpCA7dsIFkJDxnfF/odXnL8r+LbJi3ZSOzU=
+github.com/StackVista/datadog-agent-upstream-for-process-agent v0.0.0-20240618142204-94efd72cde98/go.mod h1:b87zqQerXQiLND+Ma6sRteu/wX0Uk6DAkKtSFJegF4c=
 github.com/StackVista/netlink v0.0.0-20231207101142-91d41874606b h1:9UZEx5+IBk26JfiMnUrNwE7J5bcC5zYtWwI4O8Q540I=
 github.com/StackVista/netlink v0.0.0-20231207101142-91d41874606b/go.mod h1:twkDnbuQxJYemMlGd4JFIcuhgX83tXhKS2B/PRMpOho=
 github.com/StackVista/sketches-go v1.2.0-pre h1:04QAbYurRVq5LY6VK0KbFPUi4YhJcpEi5AansGdLdMw=

--- a/go.sum
+++ b/go.sum
@@ -191,8 +191,8 @@ github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d h1:UrqY+r/O
 github.com/StackExchange/wmi v0.0.0-20181212234831-e0a55b97c705/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/StackExchange/wmi v1.2.1 h1:VIkavFPXSjcnS+O8yTq7NI32k0R5Aj+v39y29VYDOSA=
 github.com/StackExchange/wmi v1.2.1/go.mod h1:rcmrprowKIVzvc+NUiLncP2uuArMWLCbu9SBzvHz7e8=
-github.com/StackVista/datadog-agent-upstream-for-process-agent v0.0.0-20240617080032-c7e8e449f9e1 h1:nfna/saQ8g9/eQtdkcdH2riQZerEfiM6OX5tvhTCNVw=
-github.com/StackVista/datadog-agent-upstream-for-process-agent v0.0.0-20240617080032-c7e8e449f9e1/go.mod h1:b87zqQerXQiLND+Ma6sRteu/wX0Uk6DAkKtSFJegF4c=
+github.com/StackVista/datadog-agent-upstream-for-process-agent v0.0.0-20240618145435-157bd324d70b h1:UVuYAKvaPSsZjkaJ+L6OZmXbIqAHJ0bgwlQV9wBrFFk=
+github.com/StackVista/datadog-agent-upstream-for-process-agent v0.0.0-20240618145435-157bd324d70b/go.mod h1:b87zqQerXQiLND+Ma6sRteu/wX0Uk6DAkKtSFJegF4c=
 github.com/StackVista/netlink v0.0.0-20231207101142-91d41874606b h1:9UZEx5+IBk26JfiMnUrNwE7J5bcC5zYtWwI4O8Q540I=
 github.com/StackVista/netlink v0.0.0-20231207101142-91d41874606b/go.mod h1:twkDnbuQxJYemMlGd4JFIcuhgX83tXhKS2B/PRMpOho=
 github.com/StackVista/sketches-go v1.2.0-pre h1:04QAbYurRVq5LY6VK0KbFPUi4YhJcpEi5AansGdLdMw=

--- a/prebuild-datadog-agent-scripts/run-datadog-agent-prebuild.sh
+++ b/prebuild-datadog-agent-scripts/run-datadog-agent-prebuild.sh
@@ -4,15 +4,22 @@
 
 set -ex
 
-if ! type "rsync" > /dev/null; then
-  apt install rsync -y --no-install-recommends
-fi
-
 # This command assumes the datadog agent to be mounted at /source-datadog-agent. To avoid outputting to that directory,
 # we make a clone before running any commands
-mkdir -p $WORKDIR
-rsync -au "$SOURCEDIR"/. $WORKDIR
-chown -R root:root $WORKDIR
+if [ -L "$WORKDIR" ] && [ -d "$WORKDIR" ]
+then
+  echo "$WORKDIR is a symlink to a directory. It is your responsibility to ensure that the directory has the up-to-date code."
+else
+
+  if ! type "rsync" > /dev/null; then
+    apt install rsync -y --no-install-recommends
+  fi
+
+  mkdir -p $WORKDIR
+  rsync -au "$SOURCEDIR"/. $WORKDIR
+  chown -R root:root $WORKDIR
+fi
+
 cd $WORKDIR
 
 # Adding a faux tag to make the build pass on the rpo with no tags


### PR DESCRIPTION
This brings in the required changes to run on Ubuntu 18.04.