### PR TITLE
STAC-22418 Fixed oversight.

### DIFF
--- a/.gitlab-ci-docker.yml
+++ b/.gitlab-ci-docker.yml
@@ -18,6 +18,6 @@ merge-manifest:
   image: ${DOCKER_PROXY_URL}/docker:20-git
   script:
     - echo "${quay_password}" | docker login --username=${quay_user} --password-stdin quay.io
-    - DST_TAG="${CI_COMMIT_SHORT_SHA}"
+    -
     - docker manifest create "${DST_REPOSITORY}:${DST_TAG}" --amend "${DST_REPOSITORY}:${DST_TAG}-amd64" --amend "${DST_REPOSITORY}:${DST_TAG}-arm64"
     - docker manifest push "${DST_REPOSITORY}:${DST_TAG}"

--- a/.gitlab-ci-docker.yml
+++ b/.gitlab-ci-docker.yml
@@ -18,6 +18,5 @@ merge-manifest:
   image: ${DOCKER_PROXY_URL}/docker:20-git
   script:
     - echo "${quay_password}" | docker login --username=${quay_user} --password-stdin quay.io
-    -
     - docker manifest create "${DST_REPOSITORY}:${DST_TAG}" --amend "${DST_REPOSITORY}:${DST_TAG}-amd64" --amend "${DST_REPOSITORY}:${DST_TAG}-arm64"
     - docker manifest push "${DST_REPOSITORY}:${DST_TAG}"

--- a/.gitlab-ci-docker.yml
+++ b/.gitlab-ci-docker.yml
@@ -1,5 +1,4 @@
 variables:
-  DST_REPOSITORY: quay.io/stackstate/stackstate-k8s-process-agent
   DOCKER_DRIVER: overlay2
   DOCKER_HOST: tcp://docker:2375
   DOCKER_TLS_CERTDIR: ""

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,11 +27,21 @@ agent_arm64:
   rules:
     - when: always
 
-merge_docker_manifest:
+.merge_docker_manifest: &merge_docker_manifest
   stage: postbuild
   needs: [ agent_x86_64, agent_arm64 ]
   trigger:
     include: .gitlab-ci-docker.yml
     strategy: depend
   rules:
-    - when: always
+    - when: on_success
+
+merge_linux_docker_manifest:
+  <<: *merge_docker_manifest
+  variables:
+    DST_REPOSITORY: quay.io/stackstate/stackstate-process-agent-test
+
+merge_k8s_docker_manifest:
+  <<: *merge_docker_manifest
+  variables:
+    DST_REPOSITORY: quay.io/stackstate/stackstate-k8s-process-agent

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -40,9 +40,21 @@ merge_linux_docker_manifest:
   <<: *merge_docker_manifest
   variables:
     DST_REPOSITORY: quay.io/stackstate/stackstate-process-agent-test
+    DST_TAG: "$CI_COMMIT_REF_NAME"
+
+merge_extra_linux_docker_manifest:
+  <<: *merge_docker_manifest
+  variables:
+    DST_REPOSITORY: quay.io/stackstate/stackstate-process-agent-test
     DST_TAG: "$CI_COMMIT_REF_NAME-$CI_COMMIT_SHORT_SHA"
 
 merge_k8s_docker_manifest:
+  <<: *merge_docker_manifest
+  variables:
+    DST_REPOSITORY: quay.io/stackstate/stackstate-k8s-process-agent
+    DST_TAG: "$CI_COMMIT_REF_NAME"
+
+merge_extra_k8s_docker_manifest:
   <<: *merge_docker_manifest
   variables:
     DST_REPOSITORY: quay.io/stackstate/stackstate-k8s-process-agent

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -40,8 +40,10 @@ merge_linux_docker_manifest:
   <<: *merge_docker_manifest
   variables:
     DST_REPOSITORY: quay.io/stackstate/stackstate-process-agent-test
+    DST_TAG: "$CI_COMMIT_REF_NAME-$CI_COMMIT_SHORT_SHA"
 
 merge_k8s_docker_manifest:
   <<: *merge_docker_manifest
   variables:
     DST_REPOSITORY: quay.io/stackstate/stackstate-k8s-process-agent
+    DST_TAG: "$CI_COMMIT_SHORT_SHA"


### PR DESCRIPTION
Main agent repo still uses "linux-docker" image for testing (stackstate-process-agent-test).

### Step 1: Link to Jira issue


### Step 2: Description of changes


### Step 3: Did you add / update tests for your changes in the right area?
- [ ] Unit/Component test		


### Step 4: I'm confident that everything is properly tested:
I got a PO / QA Approval by:
- [ ] Name

### Step 5: Can we ship this feature to production?
- [ ] Yes, I'm proud of my work. Ship it! :ship: