### PR TITLE
cleanup: Remove redundant configs

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -30,8 +30,6 @@ docker run \\
     -v /etc:/host/etc \\
     -e STS_NETWORK_TRACING_ENABLED=true \\
     -e STS_PROTOCOL_INSPECTION_ENABLED=true \\
-    -e STS_PROCESS_AGENT_ENABLED=true \\
     europe-west4-docker.pkg.dev/stackstate-sandbox-390311/dev/stackstate-process-agent:dev
 
 EOF
-

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -15,7 +15,6 @@ func main() {
 	flag.StringVar(&opts.pidfilePath, "pid", "", "Path to set pidfile for process")
 	flag.BoolVar(&opts.info, "info", false, "Show info about running process agent and exit")
 	flag.BoolVar(&opts.version, "version", false, "Print the version and exit")
-	flag.StringVar(&opts.check, "check", "", "Run a specific check and print the results. Choose from: process, connections, realtime")
 	flag.Parse()
 
 	// Set up a default config before parsing config so we log errors nicely.

--- a/cmd/agent/main_common.go
+++ b/cmd/agent/main_common.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	_ "net/http/pprof"
@@ -18,7 +17,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/pidfile"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	containers "github.com/DataDog/datadog-agent/pkg/process/util/containers"
-	"github.com/StackVista/stackstate-process-agent/checks"
 	"github.com/StackVista/stackstate-process-agent/config"
 	"github.com/StackVista/stackstate-process-agent/pkg/debug"
 	"github.com/StackVista/stackstate-receiver-go-client/pkg/httpclient"
@@ -34,7 +32,6 @@ var opts struct {
 	pidfilePath string
 	debug       bool
 	version     bool
-	check       string
 	info        bool
 }
 
@@ -85,7 +82,7 @@ func runAgent(exit chan bool) {
 		os.Exit(0)
 	}
 
-	if opts.check == "" && !opts.info && opts.pidfilePath != "" {
+	if !opts.info && opts.pidfilePath != "" {
 		err := pidfile.WritePID(opts.pidfilePath)
 		if err != nil {
 			log.Errorf("Error while writing PID file, exiting: %v", err)
@@ -144,7 +141,7 @@ func runAgent(exit chan bool) {
 		cfg.HostName, cfg.BatcherMaxBufferSize, fwd, manager, cfg.BatcherLogPayloads)
 
 	// Exit if agent is not enabled and we're not debugging a check.
-	if !cfg.Enabled && opts.check == "" {
+	if !cfg.Enabled {
 		if yamlConf != nil {
 			log.Infof(agent6DisabledMessage)
 		}
@@ -166,15 +163,6 @@ func runAgent(exit chan bool) {
 	updateDockerSocket(dockerSock)
 
 	log.Debug("Running process-agent with DEBUG logging enabled")
-	if opts.check != "" {
-		err := debugCheckResults(cfg, opts.check)
-		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
-		}
-
-		os.Exit(0)
-	}
 
 	if opts.info {
 		// using the debug port to get info to work
@@ -244,67 +232,4 @@ func makeClientHost(cfg *config.AgentConfig) *httpclient.ClientHost {
 	}
 
 	return host
-}
-
-func debugCheckResults(cfg *config.AgentConfig, check string) error {
-	sysInfo, err := checks.CollectSystemInfo()
-	if err != nil {
-		return err
-	}
-
-	if check == checks.Connections.Name() {
-		// Connections check requires process-check to have occurred first (for process creation ts)
-		checks.Process.Init(cfg, sysInfo)
-		checks.Process.Run(cfg, 0, time.Now())
-	}
-
-	names := make([]string, 0, len(checks.All))
-	for _, ch := range checks.All {
-		if ch.Name() == check {
-			err = ch.Init(cfg, sysInfo)
-			if err != nil {
-				return fmt.Errorf("error initializing check %s: %w", ch.Name(), err)
-			}
-			return printResults(cfg, ch)
-		}
-		names = append(names, ch.Name())
-	}
-	return fmt.Errorf("invalid check '%s', choose from: %v", check, names)
-}
-
-func printResults(cfg *config.AgentConfig, ch checks.Check) error {
-	// Run the check once to prime the cache.
-	if _, err := ch.Run(cfg, 0, time.Now()); err != nil {
-		return fmt.Errorf("collection error: %s", err)
-	}
-
-	if ch.Name() == checks.Connections.Name() {
-		fmt.Printf("Waiting 5 seconds to allow for active connections to transmit data\n")
-		time.Sleep(5 * time.Second)
-	}
-
-	fmt.Printf("-----------------------------\n\n")
-	fmt.Printf("\nResults for check %v\n", ch)
-	fmt.Printf("-----------------------------\n\n")
-
-	result, err := ch.Run(cfg, 1, time.Now())
-	if err != nil {
-		return fmt.Errorf("collection error: %s", err)
-	}
-
-	for _, m := range result.CollectorMessages {
-		b, err := json.MarshalIndent(m, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal error: %s", err)
-		}
-		fmt.Println(string(b))
-	}
-	for _, m := range result.Metrics {
-		b, err := json.MarshalIndent(m, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal error: %s", err)
-		}
-		fmt.Println(string(b))
-	}
-	return nil
 }

--- a/cmd/agent/main_common.go
+++ b/cmd/agent/main_common.go
@@ -67,15 +67,6 @@ func versionString() string {
 	return buf.String()
 }
 
-const (
-	agent6DisabledMessage = `process-agent not enabled.
-Set env var STS_PROCESS_AGENT_ENABLED=true or add
-process_config:
-  enabled: "true"
-to your stackstate.yaml file.
-Exiting.`
-)
-
 func runAgent(exit chan bool) {
 	if opts.version {
 		fmt.Println(versionString())
@@ -139,19 +130,6 @@ func runAgent(exit chan bool) {
 	fwd := transactionforwarder.NewTransactionalForwarder(client, manager)
 	batcher := transactionbatcher.NewTransactionalBatcher(
 		cfg.HostName, cfg.BatcherMaxBufferSize, fwd, manager, cfg.BatcherLogPayloads)
-
-	// Exit if agent is not enabled and we're not debugging a check.
-	if !cfg.Enabled {
-		if yamlConf != nil {
-			log.Infof(agent6DisabledMessage)
-		}
-
-		// a sleep is necessary to ensure that supervisor registers this process as "STARTED"
-		// If the exit is "too quick", we enter a BACKOFF->FATAL loop even though this is an expected exit
-		// http://supervisord.org/subprocess.html#process-states
-		time.Sleep(5 * time.Second)
-		return
-	}
 
 	// update docker socket path in info
 	dockerSock, err := util.GetDockerSocketPath()

--- a/config/config.go
+++ b/config/config.go
@@ -60,7 +60,6 @@ type APIEndpoint struct {
 // AgentConfig is the global config for the process-agent. This information
 // is sourced from config files and the environment variables.
 type AgentConfig struct {
-	Enabled                  bool
 	HostName                 string
 	APIEndpoints             []APIEndpoint
 	SkipSSLValidation        bool
@@ -183,7 +182,6 @@ func NewDefaultAgentConfig() *AgentConfig {
 	}
 
 	ac := &AgentConfig{
-		Enabled:                  true, // We'll always run inside of a container.
 		APIEndpoints:             []APIEndpoint{{Endpoint: u}},
 		SkipSSLValidation:        false,
 		SkipKubeletTLSVerify:     false,
@@ -349,13 +347,6 @@ func NewAgentConfig(agentYaml *YamlAgentConfig) (*AgentConfig, error) {
 // mergeEnvironmentVariables applies overrides from environment variables to the process agent configuration
 func mergeEnvironmentVariables(c *AgentConfig) *AgentConfig {
 	var err error
-	if enabled, err := isAffirmative(os.Getenv("STS_PROCESS_AGENT_ENABLED")); enabled {
-		c.Enabled = true
-		c.EnabledChecks = processChecks
-	} else if !enabled && err == nil {
-		c.Enabled = false
-	}
-
 	if v := os.Getenv("STS_HOSTNAME"); v != "" {
 		log.Info("overriding hostname from env DD_HOSTNAME value")
 		c.HostName = v

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -356,7 +356,6 @@ func TestAgentConfigYamlOnly(t *testing.T) {
 	assert.Equal("apikey_20", ep.APIKey)
 	assert.Equal("stackstate.com", ep.Endpoint.Hostname())
 	assert.Equal(10, agentConfig.QueueSize)
-	assert.Equal(true, agentConfig.Enabled)
 	assert.Equal(true, agentConfig.EnableIncrementalPublishing)
 	assert.Equal(1*time.Minute, agentConfig.IncrementalPublishingRefreshInterval)
 	assert.Equal(processChecks, agentConfig.EnabledChecks)
@@ -389,7 +388,6 @@ func TestAgentConfigYamlOnly(t *testing.T) {
 	ep = agentConfig.APIEndpoints[0]
 	assert.Equal("apikey_20", ep.APIKey)
 	assert.Equal("stackstate.com", ep.Endpoint.Hostname())
-	assert.Equal(true, agentConfig.Enabled)
 	assert.Equal(false, agentConfig.EnableIncrementalPublishing)
 	assert.Equal(2*time.Minute, agentConfig.IncrementalPublishingRefreshInterval)
 	assert.Equal(processChecks, agentConfig.EnabledChecks) // sts
@@ -414,7 +412,6 @@ func TestAgentConfigYamlOnly(t *testing.T) {
 	ep = agentConfig.APIEndpoints[0]
 	assert.Equal("apikey_20", ep.APIKey)
 	assert.Equal("stackstate.com", ep.Endpoint.Hostname())
-	assert.Equal(false, agentConfig.Enabled)
 	assert.Equal(processChecks, agentConfig.EnabledChecks) // sts
 	assert.Equal(true, agentConfig.Scrubber.Enabled)
 
@@ -446,7 +443,6 @@ func TestAgentConfigYamlOnly(t *testing.T) {
 	assert.Equal("localhost", eps[1].Endpoint.Hostname())
 	assert.Equal("bar", eps[2].APIKey)
 	assert.Equal("localhost", eps[2].Endpoint.Hostname())
-	assert.Equal(false, agentConfig.Enabled)
 	assert.Equal(processChecks, agentConfig.EnabledChecks) // sts
 	assert.Equal(true, agentConfig.Scrubber.Enabled)
 
@@ -467,7 +463,6 @@ func TestAgentConfigYamlOnly(t *testing.T) {
 	assert.Len(agentConfig.APIEndpoints, 1)
 	assert.Equal("apikey_20", agentConfig.APIEndpoints[0].APIKey)
 	assert.Equal("stackstate.com", agentConfig.APIEndpoints[0].Endpoint.Hostname())
-	assert.Equal(true, agentConfig.Enabled)
 
 	ddy = YamlAgentConfig{}
 	site = "datacathq.eu"
@@ -486,7 +481,6 @@ func TestAgentConfigYamlOnly(t *testing.T) {
 	assert.Len(agentConfig.APIEndpoints, 1)
 	assert.Equal("apikey_20", agentConfig.APIEndpoints[0].APIKey)
 	assert.Equal("stackstate.com", agentConfig.APIEndpoints[0].Endpoint.Hostname())
-	assert.Equal(true, agentConfig.Enabled)
 
 }
 
@@ -525,7 +519,6 @@ func TestStackStateNetworkConfigFromMainAgentConfig(t *testing.T) {
 	assert.Equal("apikey_20", ep.APIKey)
 	assert.Equal("stackstate.com", ep.Endpoint.Hostname())
 	assert.Equal(10, agentConfig.QueueSize)
-	assert.Equal(true, agentConfig.Enabled)
 	assert.Equal(8*time.Second, agentConfig.CheckIntervals["container"])
 	assert.Equal(30*time.Second, agentConfig.CheckIntervals["process"])
 	assert.Equal(10000, agentConfig.NetworkTracerMaxConnections)

--- a/config/yaml_config.go
+++ b/config/yaml_config.go
@@ -30,11 +30,6 @@ type YamlAgentConfig struct {
 	IncrementalPublishingRefreshInterval int `yaml:"incremental_publishing_refresh_interval"`
 	// Process-specific configuration
 	Process struct {
-		// A string indicate the enabled state of the Agent.
-		// If "false" (the default) we will only collect containers.
-		// If "true" we will collect containers and processes.
-		// If "disabled" the agent will be disabled altogether and won't start.
-		Enabled string `yaml:"enabled"`
 		// The full path to the file where process-agent logs will be written.
 		LogFile string `yaml:"log_file"`
 		// The interval, in seconds, at which we will run each check. If you want consistent
@@ -210,16 +205,6 @@ func mergeYamlConfig(agentConf *AgentConfig, yc *YamlAgentConfig) (*AgentConfig,
 
 	// Debug purpose only
 	agentConf.LocalRun = yc.LocalRun
-
-	if enabled, err := isAffirmative(yc.Process.Enabled); enabled {
-		agentConf.Enabled = true
-		agentConf.EnabledChecks = processChecks
-	} else if strings.ToLower(yc.Process.Enabled) == "disabled" {
-		agentConf.Enabled = false
-	} else if !enabled && err == nil {
-		agentConf.Enabled = true
-		agentConf.EnabledChecks = processChecks // sts
-	}
 
 	if yc.LogToConsole {
 		agentConf.LogToConsole = true

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -99,7 +99,6 @@ services:
       STS_API_KEY: "API_KEY"
       STS_PROCESS_AGENT_URL: "http://localhost:7077/stsAgent"
       STS_SKIP_SSL_VALIDATION: "true"
-      STS_PROCESS_AGENT_ENABLED: "true"
       STS_PROCESS_BLACKLIST_PATTERNS: "^s6-,^docker-,^/sbin/,^/usr/sbin,^/pause,^/usr/bin/dbus-daemon,^-bash,^su$$,^/bin/bash,/lib/systemd/,agent"
       HOST_PROC: "/host/proc"
       HOST_SYS: "/host/sys"


### PR DESCRIPTION
### Step 1: Link to Jira issue


### Step 2: Description of changes

We always want to enable the process check by default if we start the process agent. The user can choose to disable the connection check if it is not necessary

It seems that there were different checks (process, container, connections...) than in this PR https://github.com/StackVista/stackstate-process-agent/pull/133 we left  only `process` and `connections`


### Step 3: Did you add / update tests for your changes in the right area?
- [ ] Unit/Component test		


### Step 4: I'm confident that everything is properly tested:
I got a PO / QA Approval by:
- [ ] Name

### Step 5: Can we ship this feature to production?
- [ ] Yes, I'm proud of my work. Ship it! :ship: