### PR TITLE
[STAC-23168] new: add a job to push remote-kube-cache image to quay

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -78,3 +78,42 @@ notify-on-master-fail:
   tags:
     - sts-k8s-m-runner
   when: on_failure
+
+###########################
+# Job to manage pushing images to Quay
+##########################
+# To run this job you need to specify 2 variables:
+# SOURCE_IMAGE: the full URL of the image you want to push to Quay `(e.g. docker.io/stackstate/stackstate-k8s-process-agent:latest-amd64)`
+# QUAY_IMAGE: the full URL of the destination image on Quay `(e.g. quay.io/stackstate/stackstate-k8s-process-agent:latest-amd64)`
+push_image_to_quay:
+  stage: postbuild
+  image: ${DOCKER_PROXY_URL}/docker:20
+  services:
+    - name: ${DOCKER_PROXY_URL}/docker:20-dind
+  variables:
+    # We cannot access the host docker socket in GitLab CI, so we need to use the Docker-in-Docker service
+    DOCKER_HOST: tcp://docker:2375
+    DOCKER_TLS_CERTDIR: ""
+  script:
+    - |
+      if [ -z "$SOURCE_IMAGE" ]; then
+        echo "SOURCE_IMAGE not set. Please set the CI/CD variable SOURCE_IMAGE to the URL of the image to push."
+        exit 1
+      fi
+      if [ -z "$QUAY_IMAGE" ]; then
+        echo "QUAY_IMAGE not set. Please set the CI/CD variable QUAY_IMAGE to the destination URL on Quay."
+        exit 1
+      fi
+      echo "Login to Quay.io..."
+      echo "${quay_password}" | docker login --username=${quay_user} --password-stdin quay.io
+      echo "Pull source image: $SOURCE_IMAGE"
+      docker pull "$SOURCE_IMAGE"
+      echo "Tag image for Quay: $QUAY_IMAGE"
+      docker tag "$SOURCE_IMAGE" "$QUAY_IMAGE"
+      echo "Push to Quay: $QUAY_IMAGE"
+      docker push "$QUAY_IMAGE"
+  rules:
+    # We don't need the manual job on each branch, only on master
+    - if: '$CI_COMMIT_REF_NAME == "master"'
+      when: manual
+  allow_failure: false

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -96,12 +96,18 @@ push_image_to_quay:
     DOCKER_TLS_CERTDIR: ""
   script:
     - |
+      if [ ! -f remote-kube-cache-push.env ]; then
+        echo "remote-kube-cache-push.env file not found!"; exit 1;
+      fi
+      set -o allexport
+      source remote-kube-cache-push.env
+      set +o allexport
       if [ -z "$SOURCE_IMAGE" ]; then
-        echo "SOURCE_IMAGE not set. Please set the CI/CD variable SOURCE_IMAGE to the URL of the image to push."
+        echo "SOURCE_IMAGE not set"
         exit 1
       fi
       if [ -z "$QUAY_IMAGE" ]; then
-        echo "QUAY_IMAGE not set. Please set the CI/CD variable QUAY_IMAGE to the destination URL on Quay."
+        echo "QUAY_IMAGE not set"
         exit 1
       fi
       echo "Login to Quay.io..."
@@ -113,7 +119,7 @@ push_image_to_quay:
       echo "Push to Quay: $QUAY_IMAGE"
       docker push "$QUAY_IMAGE"
   rules:
-    # We don't need the manual job on each branch, only on master
-    - if: '$CI_COMMIT_REF_NAME == "master"'
-      when: manual
+    - changes:
+        - remote-kube-cache-push.env
+      if: '$CI_COMMIT_BRANCH == "master"'
   allow_failure: false

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -121,5 +121,6 @@ push_image_to_quay:
   rules:
     - changes:
         - remote-kube-cache-push.env
-      if: '$CI_COMMIT_BRANCH == "master"'
-  allow_failure: false
+      if: $CI_COMMIT_BRANCH == "master"
+      when: manual
+  allow_failure: true

--- a/remote-kube-cache-push.env
+++ b/remote-kube-cache-push.env
@@ -1,0 +1,3 @@
+# .env file for push_image_to_quay job
+SOURCE_IMAGE=docker.io/andreater/obi-k8s-cache:75fc78604a75baf80f95fac65c36590308da8e04
+QUAY_IMAGE=quay.io/stackstate/process-agent-remote-kube-cache:75fc78604a75baf80f95fac65c36590308da8e04

--- a/remote-kube-cache-push.env
+++ b/remote-kube-cache-push.env
@@ -1,3 +1,3 @@
 # .env file for push_image_to_quay job
 SOURCE_IMAGE=docker.io/andreater/obi-k8s-cache:75fc78604a75baf80f95fac65c36590308da8e04
-QUAY_IMAGE=quay.io/stackstate/process-agent-remote-kube-cache:75fc78604a75baf80f95fac65c36590308da8e04
+QUAY_IMAGE=quay.io/stackstate/process-agent-remote-kube-cache:75fc7860


### PR DESCRIPTION
### Step 1: Link to Jira issue

### Step 2: Description of changes

Add a new manual job to push the remote-kube-cache image to quay.

The idea is to provide `SOURCE_IMAGE` and `QUAY_IMAGE` variables as input to the manual job


### Step 3: Did you add / update tests for your changes in the right area?
- [ ] Unit/Component test		


### Step 4: I'm confident that everything is properly tested:
I got a PO / QA Approval by:
- [ ] Name

### Step 5: Can we ship this feature to production?
- [ ] Yes, I'm proud of my work. Ship it! :ship: