### PR TITLE
cleanup: remove `changes` rule

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -124,8 +124,6 @@ push_image_to_quay:
       echo "Push to Quay: $QUAY_IMAGE"
       docker push "$QUAY_IMAGE"
   rules:
-    - changes:
-        - remote-kube-cache-push.env
-      if: $CI_COMMIT_BRANCH == "master"
+    - if: $CI_COMMIT_BRANCH == "master"
       when: manual
   allow_failure: true


### PR DESCRIPTION
### Step 1: Link to Jira issue


### Step 2: Description of changes

Now that the job is manual, there is no need to limit it only when there is a change to `remote-kube-cache-push.env`


### Step 3: Did you add / update tests for your changes in the right area?
- [ ] Unit/Component test		


### Step 4: I'm confident that everything is properly tested:
I got a PO / QA Approval by:
- [ ] Name

### Step 5: Can we ship this feature to production?
- [ ] Yes, I'm proud of my work. Ship it! :ship: