### PR TITLE
[STAC-23435] fix: always close rootNsHandle

### DIFF
--- a/checks/net_linux.go
+++ b/checks/net_linux.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/network/tracer"
+	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"github.com/StackVista/stackstate-process-agent/config"
 	"github.com/StackVista/stackstate-process-agent/model"
 	"github.com/StackVista/stackstate-process-agent/pkg/pods"
@@ -31,6 +32,18 @@ func (c *ConnectionsCheck) Init(cfg *config.AgentConfig, _ *model.SystemInfo) er
 	t, err := retryTracerInit(cfg.NetworkTracerInitRetryDuration, cfg.NetworkTracerInitRetryAmount, conf, tracer.NewTracer)
 	if err != nil {
 		return fmt.Errorf("failed to create network tracer: %s.  Set the environment STS_NETWORK_TRACING_ENABLED to false to disable network connections reporting", err)
+	}
+
+	// Get the root NS inode so that we will reuse it when formatting connections.
+	rootHandle, err := kernel.GetRootNetNamespace(kernel.ProcFSRoot())
+	if err != nil {
+		return fmt.Errorf("Failed to get root net namespace handle: %v", err)
+	}
+	defer rootHandle.Close()
+
+	c.rootNSIno, err = kernel.GetInoForNs(rootHandle)
+	if err != nil {
+		return fmt.Errorf("failed to get root network namespace inode: %s", err)
 	}
 
 	if cfg.NetworkTracer.PodCorrelation.Enabled {

--- a/checks/net_pod_correlation.go
+++ b/checks/net_pod_correlation.go
@@ -169,6 +169,7 @@ func newPodCorrelationInfo(cfg *config.PodCorrelationConfig) (*podCorrelationInf
 		if err != nil {
 			return nil, fmt.Errorf("Failed to get root net namespace: %v", err)
 		}
+		defer rootHandle.Close()
 
 		podCorrelationInfo.rootNSIno, err = kernel.GetInoForNs(rootHandle)
 		if err != nil {


### PR DESCRIPTION
### Step 1: Link to Jira issue

https://stackstate.atlassian.net/browse/STAC-23435

### Step 2: Description of changes

From the logs, it's pretty clear that all the leaked file descriptors are related to the root ns handle

```
process-a 12012 12097 process-a       root *889r      REG                0,4         0 4026531840 net
process-a 12012 12097 process-a       root *890r      REG                0,4         0 4026531840 net
process-a 12012 12097 process-a       root *891r      REG                0,4         0 4026531840 net
process-a 12012 12097 process-a       root *892r      REG                0,4         0 4026531840 net
process-a 12012 12097 process-a       root *893r      REG                0,4         0 4026531840 net
process-a 12012 12097 process-a       root *894r      REG                0,4         0 4026531840 net
process-a 12012 12097 process-a       root *895r      REG                0,4         0 4026531840 net
process-a 12012 12097 process-a       root *896r      REG                0,4         0 4026531840 net
process-a 12012 12097 process-a       root *897r      REG                0,4         0 4026531840 net
process-a 12012 12097 process-a       root *898r      REG                0,4         0 4026531840 net
process-a 12012 12097 process-a       root *899r      REG                0,4         0 4026531840 net
process-a 12012 12097 process-a       root *900r      REG                0,4         0 4026531840 net
process-a 12012 12097 process-a       root *901r      REG                0,4         0 4026531840 net
process-a 12012 12097 process-a       root *902r      REG                0,4         0 4026531840 net
process-a 12012 12097 process-a       root *903r      REG                0,4         0 4026531840 net
process-a 12012 12097 process-a       root *904r      REG                0,4         0 4026531840 net
process-a 12012 12097 process-a       root *905r      REG                0,4         0 4026531840 net
process-a 12012 12097 process-a       root *906r      REG                0,4         0 4026531840 net
process-a 12012 12097 process-a       root *907r      REG                0,4         0 4026531840 net
```

### Step 3: Did you add / update tests for your changes in the right area?
- [ ] Unit/Component test		


### Step 4: I'm confident that everything is properly tested:
I got a PO / QA Approval by:
- [ ] Name

### Step 5: Can we ship this feature to production?
- [ ] Yes, I'm proud of my work. Ship it! :ship: