### PR TITLE
STAC-24998: Sign bot commits in update-datadog-dependency workflow

### DIFF
--- a/.github/workflows/update-datadog-dependency.yml
+++ b/.github/workflows/update-datadog-dependency.yml
@@ -23,6 +23,9 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
+          # No later step pushes via git: the updater only reads, and
+          # create-pull-request authenticates with its own token input
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
@@ -42,10 +45,13 @@ jobs:
       - name: Run updater script
         id: update
         shell: bash
+        env:
+          # Passed via env rather than interpolated into the script (template injection)
+          UPSTREAM_BRANCH: ${{ github.event.inputs.upstream_branch }}
         run: |
           set -euo pipefail
           # Use provided input if present; otherwise default to the configured default value
-          BRANCH='${{ github.event.inputs.upstream_branch }}'
+          BRANCH="${UPSTREAM_BRANCH}"
           if [ -z "$BRANCH" ]; then BRANCH='stackstate-7.62.2'; fi
           COMMIT=$(git ls-remote https://github.com/StackVista/datadog-agent-upstream-for-process-agent.git "${BRANCH}" | tail -n 1 | awk '{print $1}')
           echo "Upstream branch: $BRANCH, commit: $COMMIT"
@@ -92,6 +98,9 @@ jobs:
             Re-run this workflow with a different `upstream_branch` to refresh the PR.
           branch: update-datadog-${{ steps.update.outputs.short_commit }}
           delete-branch: true
+          # master requires signed commits (pulumi-infra branch protection);
+          # sign-commits creates the commit via the GitHub API so it is verified
+          sign-commits: true
 
       - name: No updates needed
         if: steps.update.outputs.changed != 'true'


### PR DESCRIPTION
## Why

[STAC-24998](https://stackstate.atlassian.net/browse/STAC-24998) / [pulumi-infra#121](https://github.com/StackVista/pulumi-infra/pull/121) brings `master` branch protection under Pulumi management and converges it to the org default policy, which includes **required signed commits**.

The daily `update-datadog-dependency.yml` workflow uses `peter-evans/create-pull-request` without `sign-commits`, so it creates unsigned `github-actions[bot]` commits — once the Pulumi change is applied, its PRs would no longer be mergeable.

## What

- `sign-commits: true` on the create-pull-request step: the commit is created via the GitHub GraphQL API and carries GitHub's verified signature.
- Fixes the two Zizmor findings in this workflow while touching it:
  - the `workflow_dispatch` input is passed via `env` instead of being template-interpolated into the script (template-injection, high);
  - `persist-credentials: false` on checkout — nothing pushes via git (the upstream `git ls-remote` target is public, and create-pull-request authenticates with its own `token` input).

Zizmor: `No findings to report` after the change.

## Timing

Should merge around the same time as the `pulumi up` for STAC-24998 — before the next scheduled run (daily 09:15 UTC) following the protection change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)