### PR TITLE
STAC-25251: bump Go toolchain to 1.26.5 (CVE-2026-39822, CVE-2026-42505)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/StackVista/stackstate-process-agent
 
 go 1.26.0
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 // From datadog-agent-upstream-for-process-agent, replaces done in that go mod file need to be done here too
 replace github.com/pahanini/go-grpc-bidirectional-streaming-example v0.0.0-20211027164128-cc6111af44be => github.com/DataDog/go-grpc-bidirectional-streaming-example v0.0.0-20221024060302-b9cf785c02fe


### PR DESCRIPTION
## What

Bump the Go toolchain pin from **1.26.4 → 1.26.5** (`go.mod` `toolchain` directive; the `go` language directive stays `1.26.0`).

## Why

The `stackstate-k8s-process-agent` image failed the chart CVE gate (cve-reporter Chart Image Scan run 29004030656, 2026-07-09) on the Go stdlib:

- **CVE-2026-39822** (HIGH)
- **CVE-2026-42505** (MEDIUM)

Both are fixed in Go 1.26.5.

## Mechanism

The build runs with the default `GOTOOLCHAIN=auto`, so the `toolchain` directive in `go.mod` governs the compiler that actually produces the binary (matching the scanned `go1.26.4`), regardless of the Go version the GitLab builder image installs via `gimme`. Bumping the directive to `go1.26.5` makes `go build` re-exec 1.26.5 and clears the finding.

## Validation

- Toolchain resolves to `go1.26.5`
- `go mod verify` — all modules verified
- `go vet ./config/...` — clean under go1.26.5

The full eBPF/CGO build requires the DataDog build system and is validated by the GitLab mirror pipeline. A patch-level toolchain bump does not change build behaviour that already worked on 1.26.4.

## Ticket

STAC-25251

🤖 Generated with [Claude Code](https://claude.com/claude-code)