### PR TITLE
STAC-25519 Report failed master builds to Slack via Cerberus

### DIFF
--- a/.github/workflows/cerberus-notify.yml
+++ b/.github/workflows/cerberus-notify.yml
@@ -1,0 +1,105 @@
+name: Cerberus notify
+
+# Ported from the `notify-on-master-fail` job in the retired .gitlab-ci.yml as
+# part of the GitLab -> GitHub migration (STAC-25142 / STAC-25519). The GitHub
+# migration in STAC-25420 dropped it, which left a failing master completely
+# silent -- image publishing broke on 2026-07-23 and went unnoticed for 12 days
+# (STAC-25510).
+#
+# Called by ci.yml as a terminal job so a failed master build reaches the team's
+# Slack CI channel. Cerberus is the internal notify/block Lambda (source:
+# https://gitlab.com/stackvista/devops/cerberus); the calling convention here
+# follows `cerberus-block-on-master-fail` in StackVista/stackstate's
+# .github/workflows/ci.yml, with `platform: github` in the context so Cerberus
+# builds GitHub pipeline/commit URLs rather than GitLab ones.
+#
+# `action: notify`, never `action: block`. Policy for migrated repos is notify by
+# default; blocking locks the branch (`lock_branch`) on every master failure,
+# additionally requires the Cerberus GitHub App to be installed on the repo, and
+# mutates Pulumi-managed branch protection out from under it.
+#
+# The repo's own .cerberus/cerberus_notify_failure.sh is not reused -- it was
+# deleted with the GitLab files, was built around GitLab's CI_* variables, and
+# predates the `platform` field.
+#
+# Prerequisite: CERBERUS_LAMBDA_URL must reach this repo as a REPO-level secret.
+# The org-level copy is visibility=private, which excludes this PUBLIC repo, and
+# widening it is not an option: the Cerberus endpoint is unauthenticated, so the
+# URL is the whole capability. Until the pulumi-infra change applies, this
+# workflow warns and exits 0 rather than adding a second red job to an already
+# failed run -- the annotation is the signal.
+#
+# The Slack channel is deliberately not sent. Cerberus resolves it as
+# `util.GetOrDefault(req.Context, "channel", s.Channel)`, and GetOrDefault treats
+# an empty or whitespace value as absent, so omitting `channel` falls back to the
+# Lambda's own SLACK_CHANNEL.
+
+on:
+  workflow_call:
+    inputs:
+      suite:
+        description: Suite label shown in the Slack message, e.g. build.
+        required: true
+        type: string
+    secrets:
+      # `required: false`. A caller passing `${{ secrets.X }}` for a secret the
+      # repo does not hold yields an empty string, which GitHub rejects as "not
+      # provided" against a required secret and fails the call before the run
+      # step's guard can warn -- the failure mode this workflow exists to avoid.
+      CERBERUS_LAMBDA_URL:
+        required: false
+
+# Nothing here reads the repository; the payload is built entirely from the
+# github context.
+permissions: {}
+
+jobs:
+  notify:
+    name: Notify Slack via Cerberus
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Post the failure to Cerberus
+        env:
+          CERBERUS_LAMBDA_URL: ${{ secrets.CERBERUS_LAMBDA_URL }}
+          REPOSITORY: ${{ github.repository }}
+          BRANCH: ${{ github.ref_name }}
+          PIPELINE: ${{ github.run_id }}
+          COMMIT_SHA: ${{ github.sha }}
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+          SUITE: ${{ inputs.suite }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${CERBERUS_LAMBDA_URL}" ]; then
+            echo "::warning title=Cerberus not configured::CERBERUS_LAMBDA_URL is not visible to this repo, so the ${SUITE} failure was not reported to Slack. Needs the repo-level secret from pulumi-infra (STAC-25519)."
+            exit 0
+          fi
+
+          COMMIT_TITLE=$(printf '%s' "${COMMIT_MESSAGE}" | head -n1)
+
+          curl --verbose --fail \
+            -X POST "${CERBERUS_LAMBDA_URL}" \
+            -H "Content-Type: application/json" \
+            -d "$(jq -n \
+              --arg repo "${REPOSITORY}" \
+              --arg branch "${BRANCH}" \
+              --arg pipeline "${PIPELINE}" \
+              --arg sha "${COMMIT_SHA}" \
+              --arg title "${COMMIT_TITLE}" \
+              --arg suite "${SUITE}" \
+              '{
+                action: "notify",
+                context: {
+                  platform: "github",
+                  "project.id": $repo,
+                  "project.slug": $repo,
+                  "project.name": "StackState Process Agent",
+                  branch: $branch,
+                  pipeline: $pipeline,
+                  "commit.sha": $sha,
+                  "commit.title": $title,
+                  suite: $suite
+                }
+              }'
+            )"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -331,3 +331,20 @@ jobs:
             exit 1
           fi
           echo "All required process-agent jobs passed."
+
+  # Terminal job, master only. ci-success aggregates every other job, so hanging
+  # the notification off it means one funnel for all failures rather than a
+  # notify job per pipeline job. Replaces `notify-on-master-fail` from the
+  # retired .gitlab-ci.yml (STAC-25519).
+  cerberus-notify:
+    name: Report failure to Slack (Cerberus)
+    needs: ci-success
+    if: >-
+      failure() &&
+      github.ref == 'refs/heads/master' &&
+      github.event_name == 'push'
+    uses: ./.github/workflows/cerberus-notify.yml
+    with:
+      suite: build
+    secrets:
+      CERBERUS_LAMBDA_URL: ${{ secrets.CERBERUS_LAMBDA_URL }}


### PR DESCRIPTION
Restores the `notify-on-master-fail` job we lost in the GitLab → GitHub migration. Right now a red master on this repo is completely silent.

That is not hypothetical. Image publishing to Quay broke on **23 July** and went unnoticed for **12 days** ([STAC-25510](https://stackstate.atlassian.net/browse/STAC-25510)) — master was failing the whole time and nothing told us.

Part of the GitLab CI parity work under [STAC-25142](https://stackstate.atlassian.net/browse/STAC-25142) / [STAC-25519](https://stackstate.atlassian.net/browse/STAC-25519).

## What this does

Adds a reusable `cerberus-notify.yml` and calls it from `ci.yml` as a terminal job:

```yaml
cerberus-notify:
  needs: ci-success
  if: failure() && github.ref == 'refs/heads/master' && github.event_name == 'push'
```

It hangs off `ci-success`, which already aggregates every other job, so all failures funnel through **one** notification instead of one per job. Master pushes only — PRs stay quiet.

Follows the `cerberus-block-on-master-fail` convention from `StackVista/stackstate`, sending `platform: github` so Cerberus builds GitHub pipeline/commit URLs rather than GitLab ones. `channel` is deliberately omitted: Cerberus resolves it as `util.GetOrDefault(req.Context, "channel", s.Channel)`, so leaving it out uses the Lambda's own default (per @fzhdanov — `SLACK_CHANNEL_ID` is no longer needed caller-side).

## Two decisions worth reviewing

**`action: notify`, not `block`.** Policy for migrated repos is notify by default. Blocking would lock `master` via `lock_branch` on every failure, additionally requires the Cerberus GitHub App to be installed on this repo, and mutates Pulumi-managed branch protection — a `pulumi-infra` apply during a block window silently unlocks it.

**It ships before the secret exists, on purpose.** `CERBERUS_LAMBDA_URL` is an **org** secret with `visibility=private`, and this repo is **public**, so it does not reach us. Widening org visibility is not an option — the Cerberus endpoint is unauthenticated, so the URL *is* the capability. It needs to arrive as a repo-level secret from `pulumi-infra`, which is tracked separately and blocked on the same missing stack config key as `stackstate-agent`.

Until that lands the workflow emits a warning annotation and exits 0, rather than adding a second red job to a run that is already failing. The secret is declared `required: false` for a specific reason: passing `${{ secrets.X }}` for a secret the repo lacks yields an empty string, and GitHub rejects that against a *required* secret, failing the call **before** the guard can run — exactly the failure mode this is meant to avoid. So merging this now is safe, and it starts working the moment the secret appears, with no further change here.

## Validation

- `actionlint` type-checks the reusable-workflow call. I confirmed the check is real with a negative control — renaming `suite` → `suitte` correctly produced `input "suitte" is not defined`. Clean on the new files; the two remaining findings are pre-existing in other jobs.
- `zizmor --collect=workflows,actions,dependabot .` → no findings.
- Payload exercised against a stubbed endpoint with a multi-line commit message containing `"quotes"`, `$(whoami)` and backticks. The message goes through `env:` rather than being interpolated into the script, so it is JSON-escaped, not executed, and only the first line is used as the title. Also verified: missing secret → warn + exit 0 with no call made; empty commit message → no `set -u` trip.

## Not covered here

The other two parity gaps have their own tickets and both need a decision before any code: [STAC-25520](https://stackstate.atlassian.net/browse/STAC-25520) (S3 binary publishing) and [STAC-25521](https://stackstate.atlassian.net/browse/STAC-25521) (beest verification trigger).