### PR TITLE
STAC-25521 Document beest end-to-end verification

### DIFF
--- a/Testing.md
+++ b/Testing.md
@@ -4,6 +4,38 @@ Pre-requisites:
 
 * Build the process-agent
 
+## End-to-end (beest)
+
+Local and VM testing below covers the agent in isolation. End-to-end verification against a
+real cluster and a real SUSE Observability backend is done by
+[beest](https://github.com/StackVista/beest).
+
+The GitLab pipeline had a `beest_k8s_1_33_containerd_trigger_verification` job for this. It
+was `when: manual` on every branch, so it was never automatic — someone pressed it. The
+equivalent on GitHub is to dispatch the beest workflow directly:
+
+```
+gh workflow run agent-x86.yml --repo StackVista/beest \
+  -f process_agent_branch_under_test=<your-branch>
+```
+
+Or from the beest repo's Actions tab, via *Run workflow*. The same
+`process_agent_branch_under_test` input exists on `agent-x86.yml` (x86 EKS), `arm.yml`
+(ARM EKS) and `openshift.yml` (ROSA).
+
+You do not pass a commit or an image tag. beest resolves the branch to the latest 8-character
+short SHA on it and uses that as the image tag, which is exactly what this repo's
+`publish-image` job publishes.
+
+**Images are only published from `master`.** `publish-image` and `merge-multiarch-manifest`
+in `.github/workflows/ci.yml` are gated on `refs/heads/master`, so there is no image for a
+feature-branch commit and beest will not find one to pull. In practice that means beest
+verification currently happens *after* merge. Pre-merge verification of a feature branch is
+tracked in [STAC-25521](https://stackstate.atlassian.net/browse/STAC-25521).
+
+Note that beest runs cost real AWS infrastructure and all of its AWS workflows share a single
+global concurrency lock, so runs queue rather than run in parallel.
+
 ## Local
 
 Make sure to change in the `conf-dev.yaml` the address of the StackState backend to `localhost`.


### PR DESCRIPTION
`Testing.md` covered local and Vagrant testing but said nothing about end-to-end verification, so there was no pointer to [beest](https://github.com/StackVista/beest) at all. This adds one.

Filed as a GitLab → GitHub parity gap under [STAC-25142](https://stackstate.atlassian.net/browse/STAC-25142) / [STAC-25521](https://stackstate.atlassian.net/browse/STAC-25521), for the dropped `beest_k8s_1_33_containerd_trigger_verification` job.

## The trigger job does not need reimplementing

Two things I found while looking into it:

**It was never automatic.** In `.gitlab-ci.yml` it was `when: manual` with `allow_failure: true` on *every* branch, including master. It was a button someone pressed, not part of the pipeline.

**beest has already moved to GitHub** and exposes exactly the input we need. `agent-x86.yml`, `arm.yml` and `openshift.yml` all take `process_agent_branch_under_test` via `workflow_dispatch`, so the replacement is one command:

```
gh workflow run agent-x86.yml --repo StackVista/beest \
  -f process_agent_branch_under_test=<your-branch>
```

Building a cross-repo trigger instead would mean giving this **public** repo a token with `actions: write` on a **private** one, to replace a button that is already one click away in beest's Actions tab. That did not seem like a good trade.

The two sides already line up on tagging: beest resolves the branch to the latest 8-character short SHA (`helpers/get-latest-short-sha.sh`) and uses it as the image tag, which is precisely what `publish-image` produces with `cut -c1-8`.

## The real gap, which I have documented rather than fixed

`publish-image` and `merge-multiarch-manifest` are gated on `github.ref == 'refs/heads/master'`. GitLab's `publish_k8s_docker` published a per-commit image on **every** branch, which is what made that manual beest button useful pre-merge.

So today there is no image for a feature-branch commit, and beest has nothing to pull — **beest verification only works after merge.**

That is a deliberate policy from #246 ("publish and sign immutable multi-architecture images only from `master`"), and it is a reasonable one for a public registry, so I have not touched it. Worth noting `publish-image`'s condition already allows `workflow_dispatch` — it is just ANDed with the master check — so an opt-in manual publish from a feature branch would be a small change if we decide we want pre-merge E2E back. I have left that decision on STAC-25521 rather than making it in a docs PR.

Docs only; no workflow changes.
