### PR TITLE
STAC-25529: send Cerberus bearer token from the notify workflow

### DIFF
--- a/.github/workflows/cerberus-notify.yml
+++ b/.github/workflows/cerberus-notify.yml
@@ -22,12 +22,20 @@ name: Cerberus notify
 # deleted with the GitLab files, was built around GitLab's CI_* variables, and
 # predates the `platform` field.
 #
-# Prerequisite: CERBERUS_LAMBDA_URL must reach this repo as a REPO-level secret.
-# The org-level copy is visibility=private, which excludes this PUBLIC repo, and
-# widening it is not an option: the Cerberus endpoint is unauthenticated, so the
-# URL is the whole capability. Until the pulumi-infra change applies, this
-# workflow warns and exits 0 rather than adding a second red job to an already
-# failed run -- the annotation is the signal.
+# Prerequisites: CERBERUS_LAMBDA_URL and CERBERUS_API_TOKEN must both reach this
+# repo as REPO-level secrets. The org-level copies are visibility=private, which
+# excludes this PUBLIC repo. pulumi-infra provisions the pair together
+# (github/repoVariables/resources.yaml). If either is missing this workflow warns
+# and exits 0 rather than adding a second red job to an already failed run -- the
+# annotation is the signal.
+#
+# The bearer token is not optional going forward. StackVista/cerberus#4
+# (STAC-24889) adds `Authorization: Bearer <ssm:/cerberus/api-token>` verification
+# to every non-Slack request; before it, the endpoint was entirely
+# unauthenticated. Sending the header is forward-compatible -- the currently
+# deployed Lambda ignores unknown headers -- so this works either side of that
+# deploy. Without it, the first master failure after cerberus#4 ships would get a
+# 401 and no Slack message.
 #
 # The Slack channel is deliberately not sent. Cerberus resolves it as
 # `util.GetOrDefault(req.Context, "channel", s.Channel)`, and GetOrDefault treats
@@ -48,6 +56,8 @@ on:
       # step's guard can warn -- the failure mode this workflow exists to avoid.
       CERBERUS_LAMBDA_URL:
         required: false
+      CERBERUS_API_TOKEN:
+        required: false
 
 # Nothing here reads the repository; the payload is built entirely from the
 # github context.
@@ -62,6 +72,7 @@ jobs:
       - name: Post the failure to Cerberus
         env:
           CERBERUS_LAMBDA_URL: ${{ secrets.CERBERUS_LAMBDA_URL }}
+          CERBERUS_API_TOKEN: ${{ secrets.CERBERUS_API_TOKEN }}
           REPOSITORY: ${{ github.repository }}
           BRANCH: ${{ github.ref_name }}
           PIPELINE: ${{ github.run_id }}
@@ -71,16 +82,20 @@ jobs:
         run: |
           set -euo pipefail
 
-          if [ -z "${CERBERUS_LAMBDA_URL}" ]; then
-            echo "::warning title=Cerberus not configured::CERBERUS_LAMBDA_URL is not visible to this repo, so the ${SUITE} failure was not reported to Slack. Needs the repo-level secret from pulumi-infra (STAC-25519)."
+          if [ -z "${CERBERUS_LAMBDA_URL}" ] || [ -z "${CERBERUS_API_TOKEN}" ]; then
+            echo "::warning title=Cerberus not configured::CERBERUS_LAMBDA_URL and/or CERBERUS_API_TOKEN is not visible to this repo, so the ${SUITE} failure was not reported to Slack. Both are provisioned as repo-level secrets by pulumi-infra (STAC-25519)."
             exit 0
           fi
 
           COMMIT_TITLE=$(printf '%s' "${COMMIT_MESSAGE}" | head -n1)
 
-          curl --verbose --fail \
+          # Not --verbose: it echoes request headers, and the Authorization
+          # header carries the shared token. GitHub would mask it, but not
+          # emitting it is better than relying on masking.
+          curl --fail --silent --show-error \
             -X POST "${CERBERUS_LAMBDA_URL}" \
             -H "Content-Type: application/json" \
+            -H "Authorization: Bearer ${CERBERUS_API_TOKEN}" \
             -d "$(jq -n \
               --arg repo "${REPOSITORY}" \
               --arg branch "${BRANCH}" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -348,3 +348,4 @@ jobs:
       suite: build
     secrets:
       CERBERUS_LAMBDA_URL: ${{ secrets.CERBERUS_LAMBDA_URL }}
+      CERBERUS_API_TOKEN: ${{ secrets.CERBERUS_API_TOKEN }}


### PR DESCRIPTION
## Why

[STAC-25519](https://stackstate.atlassian.net/browse/STAC-25519) restored the master-failure Slack notification that the GitHub migration dropped — the gap that let image publishing break on 2026-07-23 and go unnoticed for 12 days ([STAC-25510](https://stackstate.atlassian.net/browse/STAC-25510)).

While verifying that merge I found it has a short shelf life. [StackVista/cerberus#4](https://github.com/StackVista/cerberus/pull/4) (STAC-24889) adds authentication to the Cerberus Lambda — the endpoint was previously **completely unauthenticated**, so anyone who knew the URL could lock or unlock protected branches or post as the Cerberus Slack bot. Every non-Slack request must now carry:

```
Authorization: Bearer <ssm:/cerberus/api-token>
```

constant-time compared in `internal/auth/auth.go` → `verifyBearer`.

**That PR is still open**, so the endpoint is unauthenticated today and the workflow merged in #250 works. The moment cerberus#4 is merged and deployed, the unauthenticated POST gets a 401, `curl --fail` turns the notify job red, and no Slack message is sent — reinstating precisely the silent-master-failure condition STAC-25519 existed to remove.

Sending the header now is **forward-compatible**: the currently deployed Lambda ignores unknown headers, so this is correct either side of that deploy and there is no coordination window.

## What

- Plumb `CERBERUS_API_TOKEN` through the reusable workflow's `workflow_call.secrets` and the `ci.yml` caller.
- Send `Authorization: Bearer …` on the POST.
- Extend the guard to cover both secrets.
- Drop `curl --verbose`, which echoes request headers — that now includes the token.

`CERBERUS_API_TOKEN` already exists as a **repo-level** secret alongside `CERBERUS_LAMBDA_URL` (both provisioned 2026-08-04 by pulumi-infra), so **no pulumi-infra change is needed**. Verified against the repo's secret list.

`required: false` is deliberate and matches the URL: passing `${{ secrets.X }}` for a secret the repo lacks yields an empty string, which GitHub rejects against a *required* secret and fails the call **before** the guard can warn — the exact failure mode this workflow is built to avoid.

## Validation

- **zizmor** — clean (`--collect=workflows,actions`).
- **actionlint** — no new findings. The one `SC2153` on `ci.yml:178` is pre-existing on master (confirmed by stashing).
- **actionlint negative control** — renamed the secret to `CERBERUS_API_TOKENN` in the reusable workflow; actionlint then reported *"secret CERBERUS_API_TOKEN is not defined in ./.github/workflows/cerberus-notify.yml"*. Proves it genuinely resolves the local reusable-workflow call rather than silently passing.
- **Execution harness** — extracted the real `run:` body via a YAML parse and executed it against a stubbed `curl`:
  - `Authorization: Bearer …` is passed as a single argv element.
  - Hostile commit message `fix: "quoted" $(whoami) ` + backticks → JSON-escaped into `commit.title`, **not executed**, first line only.
  - Missing token / missing URL / both missing → warning annotation, `exit 0`, **no curl invocation**.
  - Empty commit message under `set -u` → still produces valid JSON.

## Blast radius beyond this repo

Not introduced here, but worth flagging — these callers also post to Cerberus with no token and will break the same way when cerberus#4 deploys:

- `StackVista/stackstate` — `cerberus-block-on-master-fail` in `.github/workflows/ci.yml` (this one **blocks**, so it fails closed on a locked branch)
- `StackVista/beest` — `cerberus_notify.sh`

Relates to [STAC-24889](https://stackstate.atlassian.net/browse/STAC-24889) · Fixes [STAC-25529](https://stackstate.atlassian.net/browse/STAC-25529)
