### PR TITLE
STAC-25543 Publish per-commit images for pull requests so beest can verify pre-merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,8 +202,10 @@ jobs:
     name: Publish and sign commit image (${{ matrix.arch }})
     needs: image-smoke-and-scan
     if: >-
-      github.ref == 'refs/heads/master' &&
-      (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+      (github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository) ||
+      ((github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
+      github.ref == 'refs/heads/master')
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
@@ -279,8 +281,10 @@ jobs:
     name: Publish and sign multi-architecture commit image
     needs: publish-image
     if: >-
-      github.ref == 'refs/heads/master' &&
-      (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+      (github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository) ||
+      ((github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
+      github.ref == 'refs/heads/master')
     runs-on: ubuntu-24.04
     permissions:
       contents: read


### PR DESCRIPTION
Closes the one remaining GitLab→GitHub CI parity gap on this repo.

## Problem

GitLab published a per-commit image on **every branch and MR** — `publish_k8s_docker` had no branch rules. That is what made the manual beest verification button useful: you could verify a commit *before* merging it.

The GitHub lane gates `publish-image` and `merge-multiarch-manifest` on `refs/heads/master`, so no image exists for a commit until after it has already merged. STAC-25521 closed by documenting the beest replacement but explicitly left this as the open decision.

## Change

Allow **same-repository** pull requests to publish, in addition to the existing master lane.

## Why this is safe

- **Fork PRs excluded** by `github.event.pull_request.head.repo.full_name == github.repository`, and GitHub does not expose `QUAY_PASSWORD` to fork PRs regardless.
- **The tag is already correct pre-merge.** Every job checks out `github.event.pull_request.head.sha || github.sha` and derives the 8-char short SHA from it — exactly what beest resolves a branch to, so the existing `workflow_dispatch` inputs on beest `agent-x86.yml` / `arm.yml` / `openshift.yml` line up with no change on their side.
- **No immutable-tag collision.** `push-single-arch` refuses to overwrite an existing tag, but this repo merges via merge commits (and rebase rewrites SHAs), so a master commit SHA is never equal to the PR head SHA it came from.
- **No duplicate pipelines.** Deliberately *not* adding a `push` trigger for all branches — on a public repo that would run every pipeline twice.
- `ci-success` already treats `skipped` as passing and any other non-success as failing, so a publish failure now correctly turns the PR red.

## Not restored

The `$CI_COMMIT_REF_SLUG` branch-slug multi-arch tag from `merge_k8s_docker_manifest` stays dropped — an org-wide code search found no consumers, and beest consumes the short SHA.

## Validation

- `actionlint` — no new findings (only the pre-existing `SC2153` at line 178).
- `zizmor` v1.28.0 — `No findings to report`.
- **This PR is its own test:** it is a same-repo PR, so `publish-image` and `merge-multiarch-manifest` should now run and publish `quay.io/stackstate/stackstate-k8s-process-agent:ef6d0834`.

https://stackstate.atlassian.net/browse/STAC-25543