### PR TITLE
STAC-25557: remove YAML-level comments from workflows

### DIFF
--- a/.github/workflows/cerberus-notify.yml
+++ b/.github/workflows/cerberus-notify.yml
@@ -1,47 +1,5 @@
 name: Cerberus notify
 
-# Ported from the `notify-on-master-fail` job in the retired .gitlab-ci.yml as
-# part of the GitLab -> GitHub migration (STAC-25142 / STAC-25519). The GitHub
-# migration in STAC-25420 dropped it, which left a failing master completely
-# silent -- image publishing broke on 2026-07-23 and went unnoticed for 12 days
-# (STAC-25510).
-#
-# Called by ci.yml as a terminal job so a failed master build reaches the team's
-# Slack CI channel. Cerberus is the internal notify/block Lambda (source:
-# https://gitlab.com/stackvista/devops/cerberus); the calling convention here
-# follows `cerberus-block-on-master-fail` in StackVista/stackstate's
-# .github/workflows/ci.yml, with `platform: github` in the context so Cerberus
-# builds GitHub pipeline/commit URLs rather than GitLab ones.
-#
-# `action: notify`, never `action: block`. Policy for migrated repos is notify by
-# default; blocking locks the branch (`lock_branch`) on every master failure,
-# additionally requires the Cerberus GitHub App to be installed on the repo, and
-# mutates Pulumi-managed branch protection out from under it.
-#
-# The repo's own .cerberus/cerberus_notify_failure.sh is not reused -- it was
-# deleted with the GitLab files, was built around GitLab's CI_* variables, and
-# predates the `platform` field.
-#
-# Prerequisites: CERBERUS_LAMBDA_URL and CERBERUS_API_TOKEN must both reach this
-# repo as REPO-level secrets. The org-level copies are visibility=private, which
-# excludes this PUBLIC repo. pulumi-infra provisions the pair together
-# (github/repoVariables/resources.yaml). If either is missing this workflow warns
-# and exits 0 rather than adding a second red job to an already failed run -- the
-# annotation is the signal.
-#
-# The bearer token is not optional going forward. StackVista/cerberus#4
-# (STAC-24889) adds `Authorization: Bearer <ssm:/cerberus/api-token>` verification
-# to every non-Slack request; before it, the endpoint was entirely
-# unauthenticated. Sending the header is forward-compatible -- the currently
-# deployed Lambda ignores unknown headers -- so this works either side of that
-# deploy. Without it, the first master failure after cerberus#4 ships would get a
-# 401 and no Slack message.
-#
-# The Slack channel is deliberately not sent. Cerberus resolves it as
-# `util.GetOrDefault(req.Context, "channel", s.Channel)`, and GetOrDefault treats
-# an empty or whitespace value as absent, so omitting `channel` falls back to the
-# Lambda's own SLACK_CHANNEL.
-
 on:
   workflow_call:
     inputs:
@@ -50,17 +8,11 @@ on:
         required: true
         type: string
     secrets:
-      # `required: false`. A caller passing `${{ secrets.X }}` for a secret the
-      # repo does not hold yields an empty string, which GitHub rejects as "not
-      # provided" against a required secret and fails the call before the run
-      # step's guard can warn -- the failure mode this workflow exists to avoid.
       CERBERUS_LAMBDA_URL:
         required: false
       CERBERUS_API_TOKEN:
         required: false
 
-# Nothing here reads the repository; the payload is built entirely from the
-# github context.
 permissions: {}
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,9 +44,6 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      # A general-purpose BCI builder cannot generate DataDog's eBPF artifacts.
-      # This repository-owned, architecture-specific builder is the existing
-      # supported toolchain and is also used to build the upstream agent fork.
       - name: Generate DataDog eBPF and Go artifacts
         env:
           LLVM_ARCH: ${{ matrix.llvm-arch }}
@@ -65,9 +62,6 @@ jobs:
               ./prebuild-datadog-agent.sh --generate-no-docker
             '
 
-      # The DataDog builder carries the matching compiler, Ruby, conda, LLVM,
-      # and native libraries needed by the fork. There is no equivalent BCI
-      # image that can compile this legacy eBPF dependency graph.
       - name: Verify generated code, build, and test
         env:
           BUILDER_IMAGE: ${{ matrix.builder-image }}
@@ -336,10 +330,6 @@ jobs:
           fi
           echo "All required process-agent jobs passed."
 
-  # Terminal job, master only. ci-success aggregates every other job, so hanging
-  # the notification off it means one funnel for all failures rather than a
-  # notify job per pipeline job. Replaces `notify-on-master-fail` from the
-  # retired .gitlab-ci.yml (STAC-25519).
   cerberus-notify:
     name: Report failure to Slack (Cerberus)
     needs: ci-success

--- a/.github/workflows/update-datadog-dependency.yml
+++ b/.github/workflows/update-datadog-dependency.yml
@@ -2,7 +2,6 @@ name: Update Datadog upstream dependency
 
 on:
   schedule:
-    # Every day at 09:15 UTC
     - cron: '15 9 * * *'
   workflow_dispatch:
     inputs:
@@ -12,14 +11,9 @@ on:
         default: 'stackstate-7.62.2'
 
 permissions:
-  # All write auth below uses a short-lived GitHub App installation token.
-  # The default GITHUB_TOKEN stays read-only on purpose: events raised with it
-  # are subject to GitHub's recursion-prevention rule, so a PR it opened would
-  # never trigger the required "Process-agent CI" check and could not merge.
   contents: read
 
 concurrency:
-  # Two scheduled/dispatched runs must not race on the same working branch.
   group: update-datadog-dependency
   cancel-in-progress: false
 
@@ -41,14 +35,11 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
-          # Nothing here pushes over git: the branch, the commit and the PR are
-          # all created through the API using the App token.
           persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          # Use the Go version from go.mod
           go-version-file: go.mod
           cache: true
 
@@ -64,7 +55,6 @@ jobs:
         id: update
         shell: bash
         env:
-          # Passed via env rather than interpolated into the script (template injection)
           UPSTREAM_BRANCH: ${{ github.event.inputs.upstream_branch }}
         run: |
           set -euo pipefail


### PR DESCRIPTION
House convention is uncommented YAML. Companion to StackVista/stackstate-agent-integrations#370 under the same ticket.

Pure deletion, 68 lines, no behaviour change.

Shell comments inside `run:` blocks are kept: they're string content rather than YAML syntax, and they explain non-obvious runtime behaviour where it applies.

## Verification

- every file parses to an **identical document** before and after
- all **12 `run:` blocks byte-identical**
- Zizmor reports the same **6 suppressions as pristine master** (checked by running it on both), so nothing suppression-bearing was removed
- the two shellcheck infos actionlint raises are pre-existing — necessarily, since no `run:` block changed