### PR TITLE
STAC-25576 add beest verification dispatch

### DIFF
--- a/.github/workflows/beest-verification.yml
+++ b/.github/workflows/beest-verification.yml
@@ -1,0 +1,127 @@
+name: Beest verification
+
+on:
+  workflow_dispatch:
+    inputs:
+      suite:
+        description: Which beest agent suite to run
+        type: choice
+        default: x86
+        options:
+          - x86
+          - arm
+          - both
+      process_agent_branch_under_test:
+        description: Process-agent branch beest should deploy (empty = the branch this workflow runs on)
+        type: string
+        default: ""
+      process_agent_hash_under_test:
+        description: Process-agent commit beest should pin the image to (empty = the commit this workflow runs on)
+        type: string
+        default: ""
+      scenarios:
+        description: Beest scenario selector (empty = whatever the beest workflow defaults to)
+        type: string
+        default: ""
+      no_destroy:
+        description: Keep the beest infrastructure after the run (for debugging a failure)
+        type: boolean
+        default: false
+      beest_ref:
+        description: Ref of StackVista/beest to dispatch
+        type: string
+        default: main
+
+permissions: {}
+
+concurrency:
+  group: beest-verification-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  trigger:
+    name: Trigger beest process-agent verification
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions: {}
+    steps:
+      - name: Mint GitHub App token (dispatch beest workflows)
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          client-id: ${{ vars.BEEST_GH_APP_CLIENT_ID }}
+          private-key: ${{ secrets.BEEST_GH_APP_PRIVATE_KEY }}
+          owner: StackVista
+          repositories: beest
+          permission-actions: write
+
+      - name: Dispatch beest verification
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          SUITE: ${{ inputs.suite }}
+          PROCESS_AGENT_BRANCH: ${{ inputs.process_agent_branch_under_test || github.ref_name }}
+          PROCESS_AGENT_BRANCH_INPUT: ${{ inputs.process_agent_branch_under_test }}
+          PROCESS_AGENT_HASH_INPUT: ${{ inputs.process_agent_hash_under_test }}
+          PROCESS_AGENT_SHA: ${{ github.sha }}
+          SCENARIOS: ${{ inputs.scenarios }}
+          NO_DESTROY: ${{ inputs.no_destroy }}
+          BEEST_REF: ${{ inputs.beest_ref }}
+        run: |
+          set -euo pipefail
+
+          case "${SUITE}" in
+            x86)  workflows=("agent-x86.yml") ;;
+            arm)  workflows=("arm.yml") ;;
+            both) workflows=("agent-x86.yml" "arm.yml") ;;
+            *)    echo "::error::unknown suite '${SUITE}'"; exit 1 ;;
+          esac
+
+          # A branch builds many images, so pin the exact commit rather than letting
+          # beest pick the newest build. Default to this run's SHA, but only when the
+          # branch was not overridden -- against another branch our SHA means nothing,
+          # so leave it unset and let beest fall back. ci.yml tags images with the
+          # 8-char short SHA and beest truncates to match, so send the full SHA.
+          process_agent_hash="${PROCESS_AGENT_HASH_INPUT}"
+          if [ -z "${process_agent_hash}" ] && [ -z "${PROCESS_AGENT_BRANCH_INPUT}" ]; then
+            process_agent_hash="${PROCESS_AGENT_SHA}"
+          fi
+
+          echo "process-agent branch under test: ${PROCESS_AGENT_BRANCH}"
+          echo "process-agent commit under test: ${process_agent_hash:-(unpinned - beest chart default)}"
+
+          {
+            echo "## Beest verification dispatched"
+            echo
+            echo "| field | value |"
+            echo "| --- | --- |"
+            echo "| process-agent branch under test | \`${PROCESS_AGENT_BRANCH}\` |"
+            echo "| process-agent commit under test | \`${process_agent_hash:-(unpinned - beest chart default)}\` |"
+            echo "| suite | \`${SUITE}\` |"
+            echo "| scenarios | \`${SCENARIOS:-(beest default)}\` |"
+            echo "| keep infrastructure | \`${NO_DESTROY}\` |"
+            echo "| beest ref | \`${BEEST_REF}\` |"
+            echo
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+          for wf in "${workflows[@]}"; do
+            args=(--repo StackVista/beest --ref "${BEEST_REF}")
+            args+=(--field "process_agent_branch_under_test=${PROCESS_AGENT_BRANCH}")
+            args+=(--field "no_destroy=${NO_DESTROY}")
+            if [ -n "${process_agent_hash}" ]; then
+              args+=(--field "hashes_under_test=process-agent=${process_agent_hash}")
+            fi
+            if [ -n "${SCENARIOS}" ]; then
+              args+=(--field "scenarios=${SCENARIOS}")
+            fi
+
+            echo "dispatching ${wf}"
+            gh workflow run "${wf}" "${args[@]}"
+
+            # gh does not report the queued run, and every beest AWS workflow shares
+            # one global lock, so look the run up rather than assuming it started.
+            sleep 10
+            url="$(gh run list --repo StackVista/beest --workflow "${wf}" \
+              --limit 1 --json url --jq '.[0].url' 2>/dev/null || true)"
+            fallback="https://github.com/StackVista/beest/actions/workflows/${wf}"
+            echo "- \`${wf}\` -> ${url:-${fallback}}" >> "${GITHUB_STEP_SUMMARY}"
+          done


### PR DESCRIPTION
GitLab ran `beest_k8s_1_33_containerd_trigger_verification`, passing both `PROCESS_AGENT_BRANCH_UNDER_TEST` and `PROCESS_AGENT_HASH_UNDER_TEST`. Nothing replaced it on GitHub, so process-agent changes only reach beest if someone dispatches beest by hand and picks the image themselves.

This dispatches `StackVista/beest` pinned to the commit under test. `ci.yml` tags images with the 8-char short SHA and beest truncates to match, so the full SHA is sent. The pin defaults to this run's SHA only when the branch was not overridden — against another branch our SHA identifies no image there.

**Merge order — both are required first:**
1. [StackVista/beest#63](https://github.com/StackVista/beest/pull/63) — adds the `hashes_under_test` field this dispatches to.
2. pulumi-infra must bind `BEEST_GH_APP_CLIENT_ID` / `BEEST_GH_APP_PRIVATE_KEY` to this repo (bound only to `beest` today), and the App needs `actions: write` on beest. Without it the token step fails.

Validated with actionlint and zizmor (both clean). Deliberately dispatch-only for now rather than automatic on master, so it does not stand up AWS infrastructure on every push.

Ref: STAC-25576